### PR TITLE
Make man page generation (pandoc) optional

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,9 +1,18 @@
 # This file is distributed under MIT-LICENSE. See COPYING for details.
 
-add_custom_target(generate_doc ALL
-  COMMAND pandoc -s -w man ${CMAKE_CURRENT_SOURCE_DIR}/bear.1.md -o bear.1
-  SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/bear.1.md)
+message(STATUS "Looking for pandoc")
+find_program(PANDOC_COMMAND pandoc)
 
-include(GNUInstallDirs)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bear.1
-  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+if (PANDOC_COMMAND)
+  message(STATUS "Looking for pandoc -- found")
+  add_custom_target(generate_doc ALL
+    COMMAND ${PANDOC_COMMAND} -s -w man ${CMAKE_CURRENT_SOURCE_DIR}/bear.1.md -o bear.1
+    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/bear.1.md)
+
+  include(GNUInstallDirs)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bear.1
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+else()
+  message(STATUS "Looking for pandoc -- not found")
+  message(STATUS "- skip man page generation")
+endif()


### PR DESCRIPTION
Hello,

When I tried to compile generate the build file with cmake just to try the project I had to start by installing `pandoc`. On my system, at least, it's a bit annoying to do. It require to have a Haskell installation, which is not the smallest one and then `pandoc` takes a lot of time to compile (I decided to stop it in the middle because it was too long).

This pull request makes pandoc optional.

I understand the need of the man page if you want to install a "system wide" tool like this it's good to have documentation, and I will probably take the time to install pandoc someday. But for people who wants to give it a try I think it's a bit annoying, cmake generation + project compilation take less than 2 seconds to complete, installing pandoc require 'a lot' more.
