### PR TITLE
Make processes run under bear stoppable

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -276,7 +276,7 @@ static void install_signal_handler(int signum)
 {
     struct sigaction action;
     action.sa_handler = handler;
-    action.sa_flags = 0;
+    action.sa_flags = SA_NOCLDSTOP;
     if (0 != sigemptyset(&action.sa_mask))
     {
         perror("bear: sigemptyset");


### PR DESCRIPTION
If e.g. a long-running build is run under bear

```
# bear -- make
```

and is stopped, the continued process dies since bear tries to handle `SIGCHLD`
even though all that happened was the child processes stopping and continuing.
Instead of trying to handle this case just don't handle it (since nothing bad
happened anyway).

This should fix #40 and make the fix in 88aa27 unnecessary.
