### PR TITLE
Fix a transposition of two characters in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sets the environment up to child processes and writes the output file.
 How to build
 ------------
 
-Bear should be quiet portable on UNIX OSs, it has been tested on FreeBSD,
+Bear should be quite portable on UNIX OSs, it has been tested on FreeBSD,
 Linux and OS X only.
 
 ### Prerequisites


### PR DESCRIPTION
Trival, but noticed it tonight.
