### PR TITLE
Fix issue #51: execle causes bear to segfault on 32 bit systems.

### DIFF
--- a/src/execs.c
+++ b/src/execs.c
@@ -154,7 +154,7 @@ int execl(const char * path, const char * arg, ...)
 {
     va_list args;
     va_start(args, arg);
-    char const ** argv = bear_strings_build(arg, args);
+    char const ** argv = bear_strings_build(arg, &args);
     va_end(args);
 
     report_call("execl", (char const * const *)argv);
@@ -173,7 +173,7 @@ int execlp(const char * file, const char * arg, ...)
 {
     va_list args;
     va_start(args, arg);
-    char const ** argv = bear_strings_build(arg, args);
+    char const ** argv = bear_strings_build(arg, &args);
     va_end(args);
 
     report_call("execlp", (char const * const *)argv);
@@ -193,7 +193,7 @@ int execle(const char * path, const char * arg, ...)
 {
     va_list args;
     va_start(args, arg);
-    char const ** argv = bear_strings_build(arg, args);
+    char const ** argv = bear_strings_build(arg, &args);
     char const ** envp = va_arg(args, char const **);
     va_end(args);
 

--- a/src/stringarray.c
+++ b/src/stringarray.c
@@ -25,11 +25,11 @@
 #include <stdlib.h>
 
 #ifdef CLIENT
-char const ** bear_strings_build(char const * const arg, va_list args)
+char const ** bear_strings_build(char const * const arg, va_list *args)
 {
     char const ** result = 0;
     size_t size = 0;
-    for (char const * it = arg; it; it = va_arg(args, char const *))
+    for (char const * it = arg; it; it = va_arg(*args, char const *))
     {
         result = realloc(result, (size + 1) * sizeof(char const *));
         if (0 == result)

--- a/src/stringarray.h
+++ b/src/stringarray.h
@@ -23,7 +23,7 @@
 
 #ifdef CLIENT
 #include <stdarg.h>
-char const ** bear_strings_build(char const * arg, va_list ap);
+char const ** bear_strings_build(char const * arg, va_list *ap);
 
 char const ** bear_strings_copy(char const ** const in);
 char const ** bear_strings_append(char const ** in, char const * e);

--- a/test/unit_test/main.c
+++ b/test/unit_test/main.c
@@ -137,7 +137,7 @@ char const ** bear_strings_build_stdarg_driver(char const * arg, ...)
     va_list args;
     va_start(args, arg);
 
-    char const ** result = bear_strings_build(arg, args);
+    char const ** result = bear_strings_build(arg, &args);
 
     va_end(args);
     return result;


### PR DESCRIPTION
Problem here is that we pass the va_list to bear_strings_build and then
use it again after returning.  Per the C99 standard that's not legal.
However, you can pass a pointer to the va_list, which is what we end up
doing.  See this stackoverflow question for quotes from the standard
and/or links:
http://stackoverflow.com/questions/3369588/pass-va-list-or-pointer-to-va-list
