### PR TITLE
Automatically generate Debian package dependency list with cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CPACK_RPM_PACKAGE_LICENSE "GPLv3")
 set(CPACK_RPM_PACKAGE_GROUP "Development/Tools")
 set(CPACK_RPM_PACKAGE_URL "http://github.com/rizsotto/Bear")
 set(CPACK_RPM_PACKAGE_DESCRIPTION "Bear is a tool to generate compilation database for clang tooling.")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 include(CPack)
 
 find_package(PkgConfig)


### PR DESCRIPTION
Hi,

I was delighted to see that Bear is set up to generate distribution packages with cpack. Unfortunately, at least the Debian package doesn't mention any runtime dependencies (only libconfig AFAICT). This dependency list can be generated automagically with cpack :relieved: 
