### PR TITLE
fix: exclude irrelevant files names in command

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -163,12 +163,16 @@ def format_entry(entry):
         fullname = name if os.path.isabs(name) else os.path.join(cwd, name)
         return os.path.normpath(fullname)
 
+    def exclude_source_file_except(commands, keep):
+        """ Remove source file names from command, but keep the file that's being compiled"""
+        return [x for x in commands if not is_source_file(x)] + [keep]
+
     atoms = classify_parameters(entry['command'])
     if atoms['action'] <= Action.Compile:
         for filename in atoms.get('files', []):
             if is_source_file(filename):
                 yield {'directory': entry['directory'],
-                       'command': join_command(entry['command']),
+                       'command': join_command(exclude_source_file_except(entry['command'], filename)),
                        'file': abspath(entry['directory'], filename)}
 
 


### PR DESCRIPTION
Hi, this is an improvement for generating compilation database. 

For compile commands like:
````
clang++ -c main.cpp main2.cpp
````

Currently `bear` will return:
````
[
    {
        "command": "clang++ -c main.cpp main2.cpp",
        "directory": "...",
        "file": "main.cpp"
    },
    {
        "command": "clang++ -c main.cpp main2.cpp",
        "directory": "...",
        "file": "main2.cpp"
    }
]
````

Clang has some confusion about this file because both 2 commands apply
to `main.cpp` and `main2.cpp`, which is not precise enough.

This patch will eliminate all source file names from the original
command, then add back the real target file name. And the new json
file is:
````
[
    {
        "command": "clang++ -c main.cpp",
        "directory": "...",
        "file": "main.cpp"
    },
    {
        "command": "clang++ -c main2.cpp",
        "directory": "...",
        "file": "main2.cpp"
    }
]
````

`make check` passed on Mac OS X.

Another idea is to improve the dedup logic in the driver. So we could
find out the most precise call with only 1 file argument.

Any suggestion are welcome. Thanks.
