### PR TITLE
Fix incompatible use of [].next() on Python 3

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -380,14 +380,14 @@ def classify_parameters(command):
         elif arg in {'-MD', '-MMD', '-MG', '-MP'}:
             pass
         elif arg in {'-MF', '-MT', '-MQ'}:
-            args.next()
+            next(args)
         # linker options are ignored...
         elif arg in {'-static', '-shared', '-s', '-rdynamic'}:
             pass
         elif re.match(r'^-[lL].+', arg):
             pass
         elif arg in {'-l', '-L', '-u', '-z', '-T', '-Xlinker'}:
-            args.next()
+            next(args)
         # optimalization and waring options are ignored...
         elif re.match(r'^-[mWO].+', arg):
             pass


### PR DESCRIPTION
Changed to use next([]) instead as this will work on both Python 2 and 3.

This fixes the error that occurs after the compilation process finishes:
```
bear: Something unexpected had happened.
Traceback (most recent call last):
  File "/usr/bin/bear", line 63, in main
    return capture(args)
  File "/usr/bin/bear", line 107, in capture
    json.dump(list(entries), handle, sort_keys=True, indent=4)
  File "/usr/bin/bear", line 90, in <genexpr>
    return (entry for entry in itertools.chain(previous, current)
  File "/usr/bin/bear", line 169, in format_entry
    atoms = classify_parameters(entry['command'])
  File "/usr/bin/bear", line 383, in classify_parameters
    args.next()
AttributeError: 'list_iterator' object has no attribute 'next'
```