### PR TITLE
Support Universal binaries (32 and 64) on x86 OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+SET (CMAKE_OSX_ARCHITECTURES "i386;x86_64" CACHE STRING  "Rogue")
+
 project(bear C)
 set(BEAR_VERSION "2.1.2")
 


### PR DESCRIPTION
I had some preload issues with bear on OS X caused by a mix of 32 and 64 bit binaries. Add this causing CMake to generate a fat binary on OS X which causes bear to be able to preload into either type of binary.