### PR TITLE
Make paths to sources and include files absolute.

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -157,13 +157,14 @@ def parse_exec_trace(filename):
 def format_entry(entry):
     """ Generate the desired fields for compilation database entries. """
 
-    def abspath(cwd, name):
+    def abspath(name):
         """ Create normalized absolute path from input filename. """
-        fullname = name if os.path.isabs(name) else os.path.join(cwd, name)
+        fullname = name if os.path.isabs(
+            name) else os.path.join(entry['directory'], name)
         return os.path.normpath(fullname)
 
     logging.debug('format this command: %s', entry['command'])
-    atoms = classify_parameters(entry['command'])
+    atoms = classify_parameters(entry['command'], abspath)
     if atoms['action'] <= Action.Compile:
         for source in atoms['files']:
             compiler = 'c++' if atoms['c++'] else 'cc'
@@ -172,7 +173,7 @@ def format_entry(entry):
             yield {
                 'directory': entry['directory'],
                 'command': shell_escape(command),
-                'file': abspath(entry['directory'], source)
+                'file': abspath(source)
             }
 
 
@@ -376,7 +377,7 @@ class Action(object):
     Link, Compile, Ignored = range(3)
 
 
-def classify_parameters(command):
+def classify_parameters(command, abspath):
     """ Parses the command line arguments of the given invocation. """
 
     def take(values, key, iterator):
@@ -418,9 +419,13 @@ def classify_parameters(command):
             pass
         # parameters which looks source file are taken...
         elif re.match(r'^[^-].+', arg) and is_source(arg):
-            take(state, 'files', arg)
+            take(state, 'files', abspath(arg))
         # and consider everything else as compile option.
         else:
+            # make include paths absolute
+            match = re.match(r'^(-I)(.+)', arg)
+            if match:
+                arg = match.group(1) + abspath(match.group(2))
             take(state, 'compile_options', arg)
 
     return state

--- a/test/exec_anatomy/main.c
+++ b/test/exec_anatomy/main.c
@@ -66,7 +66,7 @@ void expected_out(const char *file) {
 
     fprintf(fd, "{\n");
     fprintf(fd, "  \"directory\": \"%s\",\n", cwd);
-    fprintf(fd, "  \"command\": \"cc -c %s\",\n", file);
+    fprintf(fd, "  \"command\": \"cc -c %s/%s\",\n", cwd, file);
     fprintf(fd, "  \"file\": \"%s/%s\"\n", cwd, file);
     fprintf(fd, "}\n");
 }


### PR DESCRIPTION
clang-tidy sometimes segfaults when the compilation database contains
relative paths, see https://llvm.org/bugs/show_bug.cgi?id=24710.
Always emitting the absolute paths works around that problem.