### PR TITLE
Fix shell_escape not escaping spaces

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -221,7 +221,7 @@ def shell_escape(command):
     def escape(word):
         """ Do protect argument if that's needed. """
 
-        table = {'\\': '\\\\', '"': '\\"'}
+        table = {'\\': '\\\\', '"': '\\"', ' ': '\\ '}
         escaped = ''.join([table.get(c, c) for c in word])
 
         return '"' + escaped + '"' if needs_quote(word) else escaped


### PR DESCRIPTION
Prior to this change, If a command contained e.g. -Dtext=\"text\ with\ spaces\" or -Dtext="\"text with spaces\"", the function shell_escape did not correctly handle either case. It correctly escaped the quotes, but did not escape the spaces, resulting in it returning -D\"text with spaces\", when it should have been returning -D\"text\ with\ spaces\".