### PR TITLE
If duplicate entry found, use new flags

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -98,7 +98,7 @@ def capture(args):
             # filter out duplicate entries from both
             duplicate = duplicate_check(entry_hash)
             return (entry
-                    for entry in itertools.chain(previous, current)
+                    for entry in itertools.chain(current, previous)
                     if os.path.exists(entry['file']) and not duplicate(entry))
         return commands
 


### PR DESCRIPTION
Compilation flags can change, so it's better to replace old duplicate entries.