### PR TITLE
check errno before using perror Fixes #163

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -262,7 +262,11 @@ def parse_exec_trace(filename):
 
     logging.debug('parse exec trace file: %s', filename)
     with open(filename, 'r') as handler:
-        entry = json.load(handler)
+        try:
+            entry = json.load(handler)
+        except ValueError:
+            logging.debug('unable to parse: %s', filename)
+            return Execution(pid='', cwd='', cmd='')
         return Execution(pid=entry['pid'], cwd=entry['cwd'], cmd=entry['cmd'])
 
 

--- a/libear/ear.c
+++ b/libear/ear.c
@@ -45,6 +45,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <errno.h>
 
 #if defined HAVE_POSIX_SPAWN || defined HAVE_POSIX_SPAWNP
 #include <spawn.h>
@@ -450,7 +451,7 @@ static void bear_report_call(char const *const argv[]) {
         perror("bear: mkstemp");
         exit(EXIT_FAILURE);
     }
-    if (0 > bear_write_json_report(fd, argv, cwd, getpid())) {
+    if (0 > bear_write_json_report(fd, argv, cwd, getpid()) && errno) {
         perror("bear: writing json problem");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
perror will print "Success" if errno was not set when invoked.

This can cause BEAR to hang for odd compilation jobs like the Linux
kernel's KBuild.