### PR TITLE
Remove inclusion of xlocale.h header file

### DIFF
--- a/libear/ear.c
+++ b/libear/ear.c
@@ -39,7 +39,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <locale.h>
-#include <xlocale.h>
 #include <unistd.h>
 #include <dlfcn.h>
 #include <sys/stat.h>


### PR DESCRIPTION
xlocale.h is a non-standard header file and was removed in recent glibc 2.26 release