### PR TITLE
Add some fixes to build RPM under the CentOS 7 with CPack (#191)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CPACK_RPM_PACKAGE_LICENSE "GPLv3")
 set(CPACK_RPM_PACKAGE_GROUP "Development/Tools")
 set(CPACK_RPM_PACKAGE_URL "http://github.com/rizsotto/Bear")
 set(CPACK_RPM_PACKAGE_DESCRIPTION "Bear is a tool to generate compilation database for clang tooling.")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/man" "/usr/share/man/man1")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 include(CPack)
 

--- a/libear/CMakeLists.txt
+++ b/libear/CMakeLists.txt
@@ -31,7 +31,9 @@ if(CMAKE_THREAD_LIBS_INIT)
 endif()
 
 set(CMAKE_MACOSX_RPATH 1)
-set_target_properties(ear PROPERTIES INSTALL_RPATH "@loader_path/${CMAKE_INSTALL_LIBDIR}")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set_target_properties(ear PROPERTIES INSTALL_RPATH "@loader_path/${CMAKE_INSTALL_LIBDIR}")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 include(GNUInstallDirs)
 install(TARGETS ear


### PR DESCRIPTION
Were fixed the next errors
CPack:
    ERROR   0002: file '/usr/local/lib64/libear.so' contains an invalid rpath '@loader_path/lib64' in [@loader_path/lib64]
yum/rpm install:
    file /usr/share/man from install of bear conflicts with file from package filesystem
    file /usr/share/man/man1 from install of bear conflicts with file from package filesystem

Now we can use
```
cmake -DCMAKE_INSTALL_PREFIX=/usr ${BEAR_SRC_DIR} && cpack -G RPM
sudo yum install ./bear-*.rpm
```
to install the RPM