### PR TITLE
Fix problem with MPI compiler wrappers

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -473,7 +473,7 @@ class Compilation:
                 return ('c', parameters) if result is None else result
             # MPI compiler wrappers add extra parameters
             elif is_mpi_wrapper(executable):
-                mpi_call = get_mpi_call(executable)  # type: List[str]
+                mpi_call = get_mpi_call(command[0])  # type: List[str]
                 return cls._split_compiler(mpi_call + parameters, cc, cxx)
             # and 'compiler' 'parameters' is valid.
             elif is_c_compiler(executable):
@@ -601,13 +601,17 @@ def get_mpi_call(wrapper):
     """ Provide information on how the underlying compiler would have been
     invoked without the MPI compiler wrapper. """
 
-    for query_flags in [['-show'], ['--showme']]:
+    for query_flags in ['-show', '--showme']:
         try:
-            output = run_command([wrapper] + query_flags)
+            command = [wrapper, query_flags]
+            logging.debug('getting MPI wrapper information: %s', command)
+            output = subprocess.check_output(command)
             if output:
-                return shell_split(output[0])
+                output = shell_split(output)
+                logging.debug('output was: %s' % output)
+                return output
         except:
-            pass
+            logging.debug('error: %s' % sys.exc_info()[0])
     # Fail loud
     raise RuntimeError("Could not determinate MPI flags.")
 


### PR DESCRIPTION
I have encountered problems when trying to use Bear with a project that uses MPI.
I propose this patch, which fixes the following problems:

- `Compilation._split_compiler` calls `get_mpi_call` with the basename of the MPI wrapper, which can cause problems if the version actually used is not the first appearing in the `PATH`.

- `get_mpi_call` uses a `run_command` utility, which is defined nowhere. I fixed this using `subprocess.check_output`. Moreover,  the exception thrown by Python is silently caught, but the function fails later on. I added debugging output to help diagnose this problem in the future if it happens again.

With these fixes, Bear is now able to correctly index my entire project.