### PR TITLE
Do not skip over -cc1 compilations

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -587,7 +587,7 @@ class Compilation:
         args = iter(compiler_and_arguments[1])
         for arg in args:
             # quit when compilation pass is not involved
-            if arg in {'-E', '-cc1', '-cc1as', '-M', '-MM', '-###'}:
+            if arg in {'-E', '-cc1as', '-M', '-MM', '-###'}:
                 return None
             elif arg in {'-S', '-c'}:
                 result.phase.append(arg)


### PR DESCRIPTION
Roughly explained, the -cc1 option enables using clang command line options directly, and bypasses the gcc compatibility driver. Command lines using this should be considered compilation.

I ran into this while capturing UE4 4.20 builds, which build system invokes clang with the -cc1 option.
