### PR TITLE
Prevent source included with -include from being ignored

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -635,6 +635,10 @@ class Compilation:
                 result.output.append(next(args))
             # parameter which looks source file is taken...
             elif re.match(r'^[^-].+', arg) and classify_source(arg):
+                if len(result.flags):
+                    if result.flags[-1] == u'-include':
+                        result.flags.append(arg)
+                        continue
                 result.files.append(arg)
             # and consider everything else as compile option.
             else:


### PR DESCRIPTION
Tweak to prevent source files included via `-include` flag from being dropped from the `arguments` list. Current parsing of arguments causes an issue when a compile command uses `-include` to include a source file (in my case, a .S assembly file). For example, a compile command with the option `-include my_asm.S` ends up with `-include` in the appropriate place in the `arguments` list for this command, but `my_asm.S` gets directed into the `files` list. This causes problems for tools expecting a filename after the `-include` flag in the `arguments` list for a particular compile command.

### Fix

- [ ] New tests added
- [ ] All tests passed

### Environment
- OS: MacOS
- Bear version: 2.3.13 (2473a67)