### PR TITLE
Add --fifo, --show_consumption, and --tempdir.

### DIFF
--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -51,7 +51,6 @@ import struct
 import contextlib
 import logging
 import multiprocessing
-import enum
 import io
 
 # Map of ignored compiler option for the creation of a compilation database.
@@ -195,9 +194,8 @@ def run_build(command, *args, **kwargs):
     return exit_code
 
 
-class FifoReadStates(enum.IntEnum):
-    eWaitingHeader = 0
-    eWaitingPayload = 1
+FifoReadStates_eWaitingHeader = 0
+FifoReadStates_eWaitingPayload = 1
 
 
 def exec_rcv(executions_fifo_file, category, bear_args):
@@ -205,7 +203,7 @@ def exec_rcv(executions_fifo_file, category, bear_args):
     fifo_header_size = 32
     current_read_buffer = b""
     bytes_remaining_to_read = fifo_header_size
-    fifo_read_state = FifoReadStates.eWaitingHeader
+    fifo_read_state = FifoReadStates_eWaitingHeader
     partial_binary = {}
     with open(executions_fifo_file, "rb") as fFifoReader:
         while True:
@@ -223,7 +221,7 @@ def exec_rcv(executions_fifo_file, category, bear_args):
 
             # Being here means we have either the full header or full payload
 
-            if fifo_read_state == FifoReadStates.eWaitingHeader:
+            if fifo_read_state == FifoReadStates_eWaitingHeader:
                 # Being here means we have the full header
 
                 # Convert bytes to unicode string so we can split/parse it
@@ -240,7 +238,7 @@ def exec_rcv(executions_fifo_file, category, bear_args):
                 total_parts = int(header_split[2])
                 pid = int(header_split[3])
 
-                fifo_read_state = FifoReadStates.eWaitingPayload
+                fifo_read_state = FifoReadStates_eWaitingPayload
                 current_read_buffer = b""
                 continue
 
@@ -249,37 +247,35 @@ def exec_rcv(executions_fifo_file, category, bear_args):
             # Update bytes_remaining_to_read/fifo_read_state for next time
             # Do it now so can issue continue later when desired.
             bytes_remaining_to_read = fifo_header_size
-            fifo_read_state = FifoReadStates.eWaitingHeader
+            fifo_read_state = FifoReadStates_eWaitingHeader
 
             # Read the rest of the payload, it will be binary data
-            execution_data_binary = current_read_buffer
+            exec_bin = current_read_buffer
 
             # Reset current_read_buffer for next time when we read the header
             current_read_buffer = b""
             if total_parts > 1:
                 if part_idx == 0:
                     # Save the initial part and continue
-                    partial_binary[pid] = execution_data_binary
+                    partial_binary[pid] = exec_bin
                     continue
                 # Combine the old data with the new
-                execution_data_binary_new = partial_binary[pid]
-                execution_data_binary_new += execution_data_binary
-                execution_data_binary = execution_data_binary_new
+                exec_bin = partial_binary[pid] + exec_bin
                 if part_idx != (total_parts - 1):
                     # Still more parts coming, save what we have and move on
-                    partial_binary[pid] = execution_data_binary
+                    partial_binary[pid] = exec_bin
                     continue
                 # Got all the parts, remove this pid from the dictionary to
                 # free up memory consumption and also to clear it in case pid
                 # gets reused.
                 # Don't execute continue so that we fall into process a full
-                # execution_data_binary
+                # exec_bin
                 partial_binary.pop(pid, None)
 
             # Got the full data, parse it, and save it only if it is
             # compilation. Not saving non-compilations allows to conserve
             # memory.
-            exec_call = parse_exec_trace_binary(execution_data_binary)
+            exec_call = parse_exec_trace_binary(exec_bin)
             if exec_call is None:
                 # Trace can't be parsed, ignore it
                 continue
@@ -295,21 +291,21 @@ def exec_rcv(executions_fifo_file, category, bear_args):
                 # Compilation.iter_from_execution again later
                 # for compilation executions, but advantage is less memory
                 # required so less swapping.
-                executions_save.append(execution_data_binary)
+                executions_save.append(exec_bin)
 
     if bear_args.show_consumption:
         # Calculate the memory consumed by executions_save so it can be
         # printed.
         executions_save_list_size = 0
-        for execution_data_binary in executions_save:
-            executions_save_list_size += sys.getsizeof(execution_data_binary)
-        executions_save_list_enclosure = sys.getsizeof(executions_save)
+        for exec_bin in executions_save:
+            executions_save_list_size += sys.getsizeof(exec_bin, 0)
+        executions_save_list_enclosure = sys.getsizeof(executions_save, 0)
         print("BEAR fifo memory consumption: " +
               sizeof_fmt(executions_save_list_size
                          + executions_save_list_enclosure))
 
-    exec_calls = (parse_exec_trace_binary(execution_data_binary)
-                  for execution_data_binary in executions_save)
+    exec_calls = (parse_exec_trace_binary(exec_bin)
+                  for exec_bin in executions_save)
     current = compilations(exec_calls, category)
 
     # Now we have all the current compilations that can be iterated

--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -194,11 +194,13 @@ def run_build(command, *args, **kwargs):
     logging.debug('build finished with exit code: %d', exit_code)
     return exit_code
 
+
 class FifoReadStates(enum.IntEnum):
     eWaitingHeader = 0
     eWaitingPayload = 1
 
-def executions_receiver(executions_fifo_file, category, bear_args):
+
+def exec_rcv(executions_fifo_file, category, bear_args):
     executions_save = []
     fifo_header_size = 32
     current_read_buffer = b""
@@ -260,7 +262,9 @@ def executions_receiver(executions_fifo_file, category, bear_args):
                     partial_binary[pid] = execution_data_binary
                     continue
                 # Combine the old data with the new
-                execution_data_binary = partial_binary[pid] + execution_data_binary
+                execution_data_binary_new = partial_binary[pid]
+                execution_data_binary_new += execution_data_binary
+                execution_data_binary = execution_data_binary_new
                 if part_idx != (total_parts - 1):
                     # Still more parts coming, save what we have and move on
                     partial_binary[pid] = execution_data_binary
@@ -272,43 +276,54 @@ def executions_receiver(executions_fifo_file, category, bear_args):
                 # execution_data_binary
                 partial_binary.pop(pid, None)
 
-            # Got the full data, parse it, and save it only if it is compilation.
-            # Not saving non-compilations allows to conserve memory.
+            # Got the full data, parse it, and save it only if it is
+            # compilation. Not saving non-compilations allows to conserve
+            # memory.
             exec_call = parse_exec_trace_binary(execution_data_binary)
             if exec_call is None:
                 # Trace can't be parsed, ignore it
                 continue
 
-            compilations_this_exec = [compilation for compilation in Compilation.iter_from_execution(exec_call, category)]
+            compilations_this_ex = [compilation for compilation in
+                                    Compilation.iter_from_execution(exec_call,
+                                                                    category)]
 
-            if compilations_this_exec:
+            if compilations_this_ex:
                 # Being here means this is a compilation, so save it for later.
                 # Will use less memory if we save the binary
-                # It means we will need to repeat binary decoding and Compilation.iter_from_execution again later
-                # for compilation executions, but advantage is less memory required so less swapping.
+                # It means we will need to repeat binary decoding and
+                # Compilation.iter_from_execution again later
+                # for compilation executions, but advantage is less memory
+                # required so less swapping.
                 executions_save.append(execution_data_binary)
 
     if bear_args.show_consumption:
-        # Calculate the memory consumed by executions_save so it can be printed.
+        # Calculate the memory consumed by executions_save so it can be
+        # printed.
         executions_save_list_size = 0
         for execution_data_binary in executions_save:
             executions_save_list_size += sys.getsizeof(execution_data_binary)
         executions_save_list_enclosure = sys.getsizeof(executions_save)
-        print("BEAR fifo memory consumption: " + sizeof_fmt(executions_save_list_size + executions_save_list_enclosure))
+        print("BEAR fifo memory consumption: " +
+              sizeof_fmt(executions_save_list_size
+                         + executions_save_list_enclosure))
 
-    exec_calls = (parse_exec_trace_binary(execution_data_binary) for execution_data_binary in executions_save)
+    exec_calls = (parse_exec_trace_binary(execution_data_binary)
+                  for execution_data_binary in executions_save)
     current = compilations(exec_calls, category)
 
     # Now we have all the current compilations that can be iterated
     # through using the 'current' generator
     create_compile_database(bear_args, category, current)
 
+
 def sizeof_fmt(num, suffix='B'):
-    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
         if abs(num) < 1024.0:
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
+
 
 def run_command(command, cwd=None):
     # type: (List[str], str) -> List[str]
@@ -414,6 +429,7 @@ def intercept_build():
 
     return exit_code
 
+
 def create_compile_database(args, category, current):
     # To support incremental builds, it is desired to read elements from
     # an existing compilation database from a previous run.
@@ -423,6 +439,7 @@ def create_compile_database(args, category, current):
         CompilationDatabase.save(args.cdb, entries)
     else:
         CompilationDatabase.save(args.cdb, current)
+
 
 def capture(args, category):
     """ Implementation of compilation database generation.
@@ -440,24 +457,29 @@ def capture(args, category):
             executions_fifo_file = os.path.join(tmp_dir, "bearfifo")
 
             # Create executions_fifo_file
-            # executions_fifo_file will get deleted when 'tmp_dir' goes out of scope
+            # executions_fifo_file will get deleted when 'tmp_dir' goes out of
+            # scope
             os.mkfifo(executions_fifo_file)
 
             # Create a process object to handle the incoming FIFO messages
-            executions_receiver_process =  multiprocessing.Process(target=executions_receiver, args=(executions_fifo_file, category, args, ))
+            exec_rcv_proc = multiprocessing.Process(target=exec_rcv,
+                                                    args=(executions_fifo_file,
+                                                          category, args, ))
 
-            # Start the receiver process. Need to do this before opening the FIFO for writing below
-            # so that the open for write below will unblock after the FIFO opened for reading is
-            # created in executions_receiver_process.
-            executions_receiver_process.start()
+            # Start the receiver process. Need to do this before opening the
+            # FIFO for writing below so that the open for write below will
+            # unblock after the FIFO opened for reading is created in
+            # exec_rcv_proc.
+            exec_rcv_proc.start()
 
-            # Open a fifo writer so that the executions_receiver will continue to block waiting for
-            # data until we close the executions_fifo_file, which occurs after the build is done.
+            # Open a fifo writer so that the exec_rcv will continue to block
+            # waiting for data until we close the executions_fifo_file, which
+            # occurs after the build is done.
             with open(executions_fifo_file, "wb"):
                 exit_code = run_build(args.build, env=environment)
 
-            # Wait for the executions_receiver to finish before moving on.
-            executions_receiver_process.join()
+            # Wait for the exec_rcv to finish before moving on.
+            exec_rcv_proc.join()
 
             return exit_code, None
 
@@ -467,13 +489,17 @@ def capture(args, category):
 
         # Print the filesystem consumption of the temporary files if asked to
         if args.show_consumption:
-            du_process = subprocess.Popen(['du', '-sh', tmp_dir], stdout=subprocess.PIPE)
+            du_process = subprocess.Popen(['du', '-sh', tmp_dir],
+                                          stdout=subprocess.PIPE)
             du_output = du_process.communicate()[0].decode('utf-8')
             du_output_split = du_output.strip().split()
-            print("BEAR temporary files consumption at '" + du_output_split[1] + "' was: " + du_output_split[0])
+            print("BEAR temporary files consumption at '" +
+                  du_output_split[1] +
+                  "' was: " + du_output_split[0])
 
         # read the intercepted exec calls
-        calls = (parse_exec_trace_file(file) for file in exec_trace_files(tmp_dir))
+        calls = (parse_exec_trace_file(file)
+                 for file in exec_trace_files(tmp_dir))
         safe_calls = (x for x in calls if x is not None)
         current = compilations(safe_calls, category)
 
@@ -523,14 +549,17 @@ def setup_environment(args, destination):
 
     return environment
 
+
 def parse_exec_trace_file(filename):
     logging.debug('parse exec trace file: %s', filename)
     with open(filename, 'rb', buffering=0) as handler:
         return parse_exec_trace_handler(handler)
 
+
 def parse_exec_trace_binary(execution_binary):
     handler = io.BytesIO(execution_binary)
     return parse_exec_trace_handler(handler)
+
 
 def parse_exec_trace_handler(handler):
     # type: (file handle) -> Optional[Execution]
@@ -662,7 +691,8 @@ def create_intercept_parser():
     advanced.add_argument(
         '--show_consumption',
         action='store_true',
-        help="""Show consumption used by execution data (temp files or fifo)""")
+        help="""Show consumption used by execution data
+        (temp files or fifo)""")
     advanced.add_argument(
         '--tempdir', '-t',
         dest='tempdir',

--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -50,6 +50,9 @@ import shutil
 import struct
 import contextlib
 import logging
+import multiprocessing
+import enum
+import io
 
 # Map of ignored compiler option for the creation of a compilation database.
 # This map is used in _split_command method, which classifies the parameters
@@ -191,6 +194,121 @@ def run_build(command, *args, **kwargs):
     logging.debug('build finished with exit code: %d', exit_code)
     return exit_code
 
+class FifoReadStates(enum.IntEnum):
+    eWaitingHeader = 0
+    eWaitingPayload = 1
+
+def executions_receiver(executions_fifo_file, category, bear_args):
+    executions_save = []
+    fifo_header_size = 32
+    current_read_buffer = b""
+    bytes_remaining_to_read = fifo_header_size
+    fifo_read_state = FifoReadStates.eWaitingHeader
+    partial_binary = {}
+    with open(executions_fifo_file, "rb") as fFifoReader:
+        while True:
+            fifo_data_in = fFifoReader.read(bytes_remaining_to_read)
+            if fifo_data_in == b"":
+                # No more writers to the fifo and no more data to read
+                # from the fifo, so we're done with everything and can exit
+                # the read loop.
+                break
+            current_read_buffer += fifo_data_in
+            bytes_remaining_to_read -= len(fifo_data_in)
+            if bytes_remaining_to_read > 0:
+                # Still need to read more to finish getting header or payload
+                continue
+
+            # Being here means we have either the full header or full payload
+
+            if fifo_read_state == FifoReadStates.eWaitingHeader:
+                # Being here means we have the full header
+
+                # Convert bytes to unicode string so we can split/parse it
+                current_read_buffer = current_read_buffer.decode('utf-8')
+
+                header_split = current_read_buffer.split()
+
+                # Header format is:
+                # payload_size part_idx total_parts pid
+
+                bytes_remaining_to_read = int(header_split[0])
+
+                part_idx = int(header_split[1])
+                total_parts = int(header_split[2])
+                pid = int(header_split[3])
+
+                fifo_read_state = FifoReadStates.eWaitingPayload
+                current_read_buffer = b""
+                continue
+
+            # Being here means we have the full payload
+
+            # Update bytes_remaining_to_read/fifo_read_state for next time
+            # Do it now so can issue continue later when desired.
+            bytes_remaining_to_read = fifo_header_size
+            fifo_read_state = FifoReadStates.eWaitingHeader
+
+            # Read the rest of the payload, it will be binary data
+            execution_data_binary = current_read_buffer
+
+            # Reset current_read_buffer for next time when we read the header
+            current_read_buffer = b""
+            if total_parts > 1:
+                if part_idx == 0:
+                    # Save the initial part and continue
+                    partial_binary[pid] = execution_data_binary
+                    continue
+                # Combine the old data with the new
+                execution_data_binary = partial_binary[pid] + execution_data_binary
+                if part_idx != (total_parts - 1):
+                    # Still more parts coming, save what we have and move on
+                    partial_binary[pid] = execution_data_binary
+                    continue
+                # Got all the parts, remove this pid from the dictionary to
+                # free up memory consumption and also to clear it in case pid
+                # gets reused.
+                # Don't execute continue so that we fall into process a full
+                # execution_data_binary
+                partial_binary.pop(pid, None)
+
+            # Got the full data, parse it, and save it only if it is compilation.
+            # Not saving non-compilations allows to conserve memory.
+            exec_call = parse_exec_trace_binary(execution_data_binary)
+            if exec_call is None:
+                # Trace can't be parsed, ignore it
+                continue
+
+            compilations_this_exec = [compilation for compilation in Compilation.iter_from_execution(exec_call, category)]
+
+            if compilations_this_exec:
+                # Being here means this is a compilation, so save it for later.
+                # Will use less memory if we save the binary
+                # It means we will need to repeat binary decoding and Compilation.iter_from_execution again later
+                # for compilation executions, but advantage is less memory required so less swapping.
+                executions_save.append(execution_data_binary)
+
+    if bear_args.show_consumption:
+        # Calculate the memory consumed by executions_save so it can be printed.
+        executions_save_list_size = 0
+        for execution_data_binary in executions_save:
+            executions_save_list_size += sys.getsizeof(execution_data_binary)
+        executions_save_list_enclosure = sys.getsizeof(executions_save)
+        print("BEAR fifo memory consumption: " + sizeof_fmt(executions_save_list_size + executions_save_list_enclosure))
+
+    exec_calls = (parse_exec_trace_binary(execution_data_binary) for execution_data_binary in executions_save)
+    current = compilations(exec_calls, category)
+
+    # Now we have all the current compilations that can be iterated
+    # through using the 'current' generator
+    create_compile_database(bear_args, category, current)
+
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
 
 def run_command(command, cwd=None):
     # type: (List[str], str) -> List[str]
@@ -291,6 +409,12 @@ def intercept_build():
     category = Category(args.use_only, args.use_cc, args.use_cxx)
     exit_code, current = capture(args, category)
 
+    if not args.fifo:
+        create_compile_database(args, category, current)
+
+    return exit_code
+
+def create_compile_database(args, category, current):
     # To support incremental builds, it is desired to read elements from
     # an existing compilation database from a previous run.
     if args.append and os.path.isfile(args.cdb):
@@ -300,9 +424,6 @@ def intercept_build():
     else:
         CompilationDatabase.save(args.cdb, current)
 
-    return exit_code
-
-
 def capture(args, category):
     """ Implementation of compilation database generation.
 
@@ -310,12 +431,49 @@ def capture(args, category):
     :param category:    helper object to detect compiler
     :return:            the exit status of build process. """
 
-    with temporary_directory(prefix='intercept-') as tmp_dir:
+    with temporary_directory(prefix='intercept-', dir=args.tempdir) as tmp_dir:
         # run the build command
         environment = setup_environment(args, tmp_dir)
+
+        if args.fifo:
+            logging.debug('FIFO or FILE: FIFO')
+            executions_fifo_file = os.path.join(tmp_dir, "bearfifo")
+
+            # Create executions_fifo_file
+            # executions_fifo_file will get deleted when 'tmp_dir' goes out of scope
+            os.mkfifo(executions_fifo_file)
+
+            # Create a process object to handle the incoming FIFO messages
+            executions_receiver_process =  multiprocessing.Process(target=executions_receiver, args=(executions_fifo_file, category, args, ))
+
+            # Start the receiver process. Need to do this before opening the FIFO for writing below
+            # so that the open for write below will unblock after the FIFO opened for reading is
+            # created in executions_receiver_process.
+            executions_receiver_process.start()
+
+            # Open a fifo writer so that the executions_receiver will continue to block waiting for
+            # data until we close the executions_fifo_file, which occurs after the build is done.
+            with open(executions_fifo_file, "wb"):
+                exit_code = run_build(args.build, env=environment)
+
+            # Wait for the executions_receiver to finish before moving on.
+            executions_receiver_process.join()
+
+            return exit_code, None
+
+        # Not using the FIFO
+        logging.debug('FIFO or FILE: FILE')
         exit_code = run_build(args.build, env=environment)
+
+        # Print the filesystem consumption of the temporary files if asked to
+        if args.show_consumption:
+            du_process = subprocess.Popen(['du', '-sh', tmp_dir], stdout=subprocess.PIPE)
+            du_output = du_process.communicate()[0].decode('utf-8')
+            du_output_split = du_output.strip().split()
+            print("BEAR temporary files consumption at '" + du_output_split[1] + "' was: " + du_output_split[0])
+
         # read the intercepted exec calls
-        calls = (parse_exec_trace(file) for file in exec_trace_files(tmp_dir))
+        calls = (parse_exec_trace_file(file) for file in exec_trace_files(tmp_dir))
         safe_calls = (x for x in calls if x is not None)
         current = compilations(safe_calls, category)
 
@@ -350,6 +508,8 @@ def setup_environment(args, destination):
     :param destination: directory path for the execution trace files
     :return: a prepared set of environment variables. """
 
+    logging.debug('INTERCEPT_BUILD_TARGET_DIR: %s', str(destination))
+
     environment = dict(os.environ)
     environment.update({'INTERCEPT_BUILD_TARGET_DIR': destination})
 
@@ -363,15 +523,23 @@ def setup_environment(args, destination):
 
     return environment
 
+def parse_exec_trace_file(filename):
+    logging.debug('parse exec trace file: %s', filename)
+    with open(filename, 'rb', buffering=0) as handler:
+        return parse_exec_trace_handler(handler)
 
-def parse_exec_trace(filename):
-    # type: (str) -> Optional[Execution]
-    """ Parse execution report file.
+def parse_exec_trace_binary(execution_binary):
+    handler = io.BytesIO(execution_binary)
+    return parse_exec_trace_handler(handler)
 
-    Given filename points to a file which contains the basic report
+def parse_exec_trace_handler(handler):
+    # type: (file handle) -> Optional[Execution]
+    """ Parse execution report
+
+    Given file handler contains the basic report
     generated by the interception library or compiler wrapper.
 
-    :param filename: path to an execution trace file to read from,
+    :param handler: file handler to an execution trace stream to read from,
     :return: an Execution object. """
 
     def byte_to_int(byte):
@@ -393,15 +561,13 @@ def parse_exec_trace(filename):
         length = parse_length(handler, b'lst')
         return [parse_string(handler) for _ in range(length)]
 
-    logging.debug('parse exec trace file: %s', filename)
-    with open(filename, 'rb', buffering=0) as handler:
-        try:
-            return Execution(cwd=parse_string(handler),
-                             cmd=parse_string_list(handler))
-        except Exception as exception:
-            logging.warning('parse exec trace file: %s FAILED: %s',
-                            filename, exception)
-            return None
+    try:
+        return Execution(cwd=parse_string(handler),
+                         cmd=parse_string_list(handler))
+    except Exception as exception:
+        logging.warning('parse exec trace binary: FAILED: %s',
+                        exception)
+        return None
 
 
 def exec_trace_files(directory):
@@ -489,6 +655,20 @@ def create_intercept_parser():
         default="@DEFAULT_PRELOAD_FILE@",
         action='store',
         help="""specify libear file location.""")
+    advanced.add_argument(
+        '--fifo', '-f',
+        action='store_true',
+        help="""Use a FIFO instead of temp files.""")
+    advanced.add_argument(
+        '--show_consumption',
+        action='store_true',
+        help="""Show consumption used by execution data (temp files or fifo)""")
+    advanced.add_argument(
+        '--tempdir', '-t',
+        dest='tempdir',
+        default=None,
+        action='store',
+        help="""specify temporary directory.""")
 
     parser.add_argument(
         dest='build', nargs=argparse.REMAINDER, help="""Command to run.""")

--- a/libear/ear.c
+++ b/libear/ear.c
@@ -92,8 +92,8 @@ extern char **environ;
 
 typedef char const * bear_env_t[ENV_SIZE];
 
-const int fifo_header_size = 32;
-const int max_fifo_payload_size = PIPE_BUF - fifo_header_size;
+#define FIFO_HEADER_SIZE 32
+const int max_fifo_payload_size = (PIPE_BUF - FIFO_HEADER_SIZE);
 
 enum Report_Type {
     REPORT_FIFO,
@@ -601,13 +601,13 @@ static void report_buf_write_fifo(struct Report_buf *report_buf) {
         // The formatting in snprintf below is designed to exactly fit in 32 bytes
         // as the FIFO header. Add 1 to make room for null character byte which will
         // get overwritten with the payload.
-        snprintf(fifo_packet, fifo_header_size + 1, "%8d %5d %5d %8d  \n", payload_size, part_idx, total_parts, pid);
+        snprintf(fifo_packet, FIFO_HEADER_SIZE + 1, "%8d %5d %5d %8d  \n", payload_size, part_idx, total_parts, pid);
 
         // Copy the payload of the packet into the FIFO packet buffer after the header.
-        memcpy(&(fifo_packet[fifo_header_size]), &(report_buf->report_buf_[packet_pos_in_report_buf]), payload_size);
+        memcpy(&(fifo_packet[FIFO_HEADER_SIZE]), &(report_buf->report_buf_[packet_pos_in_report_buf]), payload_size);
 
         // Write the FIFO packet into the FIFO buffer
-        if (-1 == write(fd_fifo, fifo_packet, fifo_header_size + payload_size)) {
+        if (-1 == write(fd_fifo, fifo_packet, FIFO_HEADER_SIZE + payload_size)) {
             PERROR("write fifo");
             got_error = 1;
             break;

--- a/test/functional/cases/end-to-end/qmake.ft
+++ b/test/functional/cases/end-to-end/qmake.ft
@@ -1,5 +1,5 @@
 # REQUIRES: make,qmake,preload
 # RUN: mkdir -p %T/qmake_build
 # RUN: cd %T/qmake_build; %{qmake} ../../Input/qmake.pro
-# RUN: cd %T/qmake_build; %{intercept-build} --cdb qmake.json %{make}
+# RUN: cd %T/qmake_build; %{intercept-build} --show_consumption --cdb qmake.json %{make}
 # RUN: %{python} %S/check_files.py %T/qmake_build/qmake.json

--- a/test/functional/cases/end-to-end/scons.ft
+++ b/test/functional/cases/end-to-end/scons.ft
@@ -1,4 +1,4 @@
 # REQUIRES: scons,preload
 # RUN: mkdir -p %T/scons_build
-# RUN: cd %T/scons_build; %{intercept-build} --cdb scons.json scons -Y ../../Input
+# RUN: cd %T/scons_build; %{intercept-build} --fifo --cdb scons.json scons -Y ../../Input
 # RUN: %{python} %S/check_files.py %T/scons_build/scons.json

--- a/test/functional/cases/exec_calls/run_exec_test.ft
+++ b/test/functional/cases/exec_calls/run_exec_test.ft
@@ -1,5 +1,5 @@
 # REQUIRES: preload
 # RUN: cmake -B%T -H%S
 # RUN: make -C %T
-# RUN: %{intercept-build} --cdb %T/result.json %T/exec -C %T -o expected.json
+# RUN: %{intercept-build} --show_consumption --cdb %T/result.json %T/exec -C %T -o expected.json
 # RUN: %{cdb_diff} %T/result.json %T/expected.json

--- a/test/functional/cases/intercept/broken_build.fts
+++ b/test/functional/cases/intercept/broken_build.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/broken_build
-# RUN: cd %T/broken_build; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/broken_build; %{intercept-build} --fifo --cdb preload.json ./run.sh
 # RUN: cd %T/broken_build; %{cdb_diff} preload.json expected.json
 
 set -o errexit

--- a/test/functional/cases/intercept/empty_argument.fts
+++ b/test/functional/cases/intercept/empty_argument.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/empty_argument
-# RUN: cd %T/empty_argument; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/empty_argument; %{intercept-build} --fifo --cdb preload.json ./run.sh
 # RUN: cd %T/empty_argument; %{cdb_diff} preload.json expected.json
 
 set -o errexit

--- a/test/functional/cases/intercept/noisy_build.fts
+++ b/test/functional/cases/intercept/noisy_build.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/noisy_build
-# RUN: cd %T/noisy_build; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/noisy_build; %{intercept-build} --fifo --show_consumption --cdb preload.json ./run.sh
 # RUN: cd %T/noisy_build; %{cdb_diff} preload.json expected.json
 
 set -o errexit

--- a/test/functional/cases/intercept/successful_build.fts
+++ b/test/functional/cases/intercept/successful_build.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/successful_build
-# RUN: cd %T/successful_build; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/successful_build; %{intercept-build} --fifo --cdb preload.json ./run.sh
 # RUN: cd %T/successful_build; %{cdb_diff} preload.json expected.json
 
 set -o errexit

--- a/test/functional/cases/intercept/unkown_compiler_recognised.fts
+++ b/test/functional/cases/intercept/unkown_compiler_recognised.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/unkown_compiler_recognised
-# RUN: cd %T/unkown_compiler_recognised; %{intercept-build} --use-cc=%T/unkown_compiler_recognised/wrapper --use-c++=%T/unkown_compiler_recognised/wrapper++ --cdb wrapper.json ./run.sh
+# RUN: cd %T/unkown_compiler_recognised; %{intercept-build} --show_consumption --fifo --use-cc=%T/unkown_compiler_recognised/wrapper --use-c++=%T/unkown_compiler_recognised/wrapper++ --cdb wrapper.json ./run.sh
 # RUN: cd %T/unkown_compiler_recognised; %{cdb_diff} wrapper.json expected.json
 # RUN: cd %T/unkown_compiler_recognised; %{intercept-build} --use-only --use-cc=%T/unkown_compiler_recognised/wrapper --use-c++=%T/unkown_compiler_recognised/wrapper++ --cdb wrapper_only.json ./run.sh
 # RUN: cd %T/unkown_compiler_recognised; %{cdb_diff} wrapper_only.json expected_wrapper_only.json

--- a/test/functional/cases/result/assembly_sources.fts
+++ b/test/functional/cases/result/assembly_sources.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/assembly_sources
-# RUN: cd %T/assembly_sources; %{intercept-build} --cdb preload.json make -C src
+# RUN: cd %T/assembly_sources; %{intercept-build} --show_consumption --cdb preload.json make -C src
 # RUN: cd %T/assembly_sources; %{cdb_diff} preload.json expected.json
 
 set -o errexit

--- a/test/functional/cases/result/define_with_nonutf_encode.fts
+++ b/test/functional/cases/result/define_with_nonutf_encode.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/define_with_nonutf_encode
-# RUN: cd %T/define_with_nonutf_encode; %{intercept-build} --cdb result.json ./run.sh
+# RUN: cd %T/define_with_nonutf_encode; %{intercept-build} --fifo --cdb result.json ./run.sh
 
 set -o errexit
 set -o nounset

--- a/test/functional/cases/result/define_with_unicode.fts
+++ b/test/functional/cases/result/define_with_unicode.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/define_with_unicode
-# RUN: cd %T/define_with_unicode; %{intercept-build} --cdb result.json ./run.sh
+# RUN: cd %T/define_with_unicode; %{intercept-build} --fifo --cdb result.json ./run.sh
 # RUN: cd %T/define_with_unicode; %{cdb_diff} result.json expected.json
 
 set -o errexit

--- a/test/functional/cases/result/duplicate_entries.fts
+++ b/test/functional/cases/result/duplicate_entries.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/duplicate_entries
-# RUN: cd %T/duplicate_entries; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/duplicate_entries; %{intercept-build} --fifo --show_consumption --cdb preload.json ./run.sh
 # RUN: cd %T/duplicate_entries; %{cdb_diff} preload.json expected.json
 
 set -o errexit

--- a/test/functional/cases/result/extend_build.fts
+++ b/test/functional/cases/result/extend_build.fts
@@ -4,7 +4,7 @@
 # RUN: bash %s %T/extend_build
 # RUN: cd %T/extend_build; %{intercept-build} --cdb result.json ./run-one.sh
 # RUN: cd %T/extend_build; %{cdb_diff} result.json one.json
-# RUN: cd %T/extend_build; %{intercept-build} --cdb result.json ./run-two.sh
+# RUN: cd %T/extend_build; %{intercept-build} --fifo --show_consumption --cdb result.json ./run-two.sh
 # RUN: cd %T/extend_build; %{cdb_diff} result.json two.json
 # RUN: cd %T/extend_build; %{intercept-build} --cdb result.json --append ./run-one.sh
 # RUN: cd %T/extend_build; %{cdb_diff} result.json sum.json

--- a/test/functional/cases/result/extend_build_with_missing.fts
+++ b/test/functional/cases/result/extend_build_with_missing.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/extend_build_with_missing
-# RUN: cd %T/extend_build_with_missing; %{intercept-build} --cdb result.json ./run-one.sh
+# RUN: cd %T/extend_build_with_missing; %{intercept-build} --fifo --cdb result.json ./run-one.sh
 # RUN: cd %T/extend_build_with_missing; %{cdb_diff} result.json one.json
 # RUN: cd %T/extend_build_with_missing; rm src/one.c
 # RUN: cd %T/extend_build_with_missing; %{intercept-build} --cdb result.json --append ./run-two.sh

--- a/test/functional/cases/result/file_path_relative.fts
+++ b/test/functional/cases/result/file_path_relative.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/file_path_relative
-# RUN: cd %T/file_path_relative; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/file_path_relative; %{intercept-build} --fifo --cdb preload.json ./run.sh
 # RUN: cd %T/file_path_relative; %{python} is_file.py preload.json
 # RUN: cd %T/file_path_relative; %{python} is_rel.py preload.json
 

--- a/test/functional/cases/result/flags_filtered.fts
+++ b/test/functional/cases/result/flags_filtered.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/flags_filtered
-# RUN: cd %T/flags_filtered; %{intercept-build} --cdb result.json ./run.sh
+# RUN: cd %T/flags_filtered; %{intercept-build} --show_consumption --cdb result.json ./run.sh
 # RUN: cd %T/flags_filtered; %{cdb_diff} result.json expected.json
 
 set -o errexit

--- a/test/functional/cases/result/multiple_source_build.fts
+++ b/test/functional/cases/result/multiple_source_build.fts
@@ -2,7 +2,7 @@
 
 # REQUIRES: preload
 # RUN: bash %s %T/multiple_source_build
-# RUN: cd %T/multiple_source_build; %{intercept-build} --cdb result.json ./run.sh
+# RUN: cd %T/multiple_source_build; %{intercept-build} --fifo --cdb result.json ./run.sh
 # RUN: cd %T/multiple_source_build; %{cdb_diff} result.json expected.json
 
 set -o errexit


### PR DESCRIPTION
Here is a PR for adding an optional, alternative method to use a FIFO/pipe instead of temporary files.

This could be useful in my company because we perform nightly builds at 6 different locations. One of the locations has only 344MByte available in the standard /tmp directory, which is not enough. If we change TMPDIR to a non-standard location that does have enough space, we have found that it takes Bear a very long time to process all the temporary files after the build is over. We don't quite understand why that filesystem, which is local is so much slower. Using this new FIFO method, we take up space in memory (or swap) instead of temp files and the consolidation of all the execution calls is much faster.

Below is some data from 17 of our different builds. Notice in 16 out of 17 cases, the amount of memory taken by the FIFO method is significantly less than the disk space taken by the temporary files method. Also notice the time for Bear to consolidate all the execution data is signficantly faster in all cases.

Our build server builds many of these 17 builds in parallel so the required temp file space adds up and on the one server exceeds the available 344MByte.

See the commit message below for more information about when the new --fifo option can be useful. I also added --show_consumption and --tempdir options which are described in the commit message.

As of this time, I am still doing a build with the faster /tmp location and will update the below table with that information when the builds are completed.

```
------------------------------------|
|     |     |     |     |Slow |Fast |
|Build|FIFO |Temp |FIFO |Temp |Temp |
|Num  |     |Files|     |Files|Files|
|     |Space|Space|Time |Time |Time |
|     |MByte|MByte|MM:SS|MM:SS|MM:SS|
|=====|=====|=====|=====|=====|=====|
| 1   |188.2|  137|  :30| 4:21|     |
| 2   | 15.0|  225|  :03| 3:08|     |
| 3   | 18.5|  367|  :03|15:06|     |
| 4   |  5.9|  238|  :01|  :30|     |
| 5   |  5.0|   93|  :01|  :12|     |
| 6   |  1.2|   31|  :00|  :04|     |
| 7   | 11.0|  190|  :02|  :22|     |
| 8   | 11.4|   67|  :02|  :13|     |
| 9   |  5.9|   88|  :01|  :13|     |
|10   | 31.1|  269|  :05|  :47|     |
|11   | 26.4|  218|  :05|12:30|     |
|12   | 13.4|  333|  :03|  :40|     |
|13   |  6.5|   89|  :01|  :13|     |
|14   |  7.1|   60|  :01|  :07|     |
|15   |  9.6|  171|  :01| 3:41|     |
|16   | 11.0|  182|  :02| 6:12|     |
|17   | 12.5|  113|  :02| 1:01|     |
-------------------------------------
```

Commit message:
==================

--fifo will have bear use a linux fifo pipe instead of temp
files.

--show_consumption option will print to stdout the amount of memory
consumed by either the fifo or temp file methods.

--tempdir allows to specify a temporary directory.

A fifo pipe will use much less disk space than temporary files.
Using the fifo pipe, the bear (main.py.in) python script will receive
the execution data immediately from the C library via the pipe and can
throw away anything that is not a compilation command. The execution
data will be stored in a list that is built up over time. Using the
FIFO can also allow to save some time vs when temporary files are stored
on a slow file system. Another advantage of fifo is that it won't leave
many temporary files laying around in case BEAR is killed with SIGKILL
since SIGKILL does not give BEAR an opportunity to clean up temp files.

Updated many tests to use --fifo and --show_consumption so that they
are continuously tested.

### Fix or Enhancement?

Enhancement

- [x ] New tests added
- [ x] All tests passed

### Environment
- OS:
- Bear version:
