### PR TITLE
Add support for CUDA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
       - scons
       - gfortran
       - qt4-qmake
+      - nvidia-cuda-toolkit
 
 before_install:
   - uname

--- a/bear/main.py.in
+++ b/bear/main.py.in
@@ -114,6 +114,7 @@ COMPILER_PATTERNS_CXX = (
     re.compile(r'^([^-]*-)*[mg]\+\+(-?\d+(\.\d+){0,2})?$'),
     re.compile(r'^([^-]*-)*clang\+\+(-\d+(\.\d+){0,2})?$'),
     re.compile(r'^icpc$'),
+    re.compile(r'^nvcc$'),
     re.compile(r'^(g|)xl(C|c\+\+)$'),
 )
 
@@ -826,6 +827,7 @@ def classify_source(filename, c_compiler=True):
         '.c++': 'c++',
         '.C++': 'c++',
         '.txx': 'c++',
+        '.cu': 'c++',
         '.s': 'assembly',
         '.S': 'assembly',
         '.sx': 'assembly',

--- a/test/functional/cases/intercept/cuda/successful_build.fts
+++ b/test/functional/cases/intercept/cuda/successful_build.fts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# REQUIRES: preload
+# REQUIRES: preload,cuda
 # RUN: bash %s %T/successful_build
 # RUN: cd %T/successful_build; %{intercept-build} --cdb preload.json ./run.sh
 # RUN: cd %T/successful_build; %{cdb_diff} preload.json expected.json

--- a/test/functional/cases/intercept/cuda/successful_build.fts
+++ b/test/functional/cases/intercept/cuda/successful_build.fts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# REQUIRES: preload
+# RUN: bash %s %T/successful_build
+# RUN: cd %T/successful_build; %{intercept-build} --cdb preload.json ./run.sh
+# RUN: cd %T/successful_build; %{cdb_diff} preload.json expected.json
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+# the test creates a subdirectory inside output dir.
+#
+# ${root_dir}
+# ├── run.sh
+# ├── expected.json
+# └── src
+#    └── empty.cu
+
+root_dir=$1
+mkdir -p "${root_dir}/src"
+
+touch "${root_dir}/src/empty.cu"
+
+build_file="${root_dir}/run.sh"
+cat > ${build_file} << EOF
+#!/usr/bin/env bash
+
+set -o nounset
+set -o xtrace
+
+nvcc -c -Dver=1 src/empty.cu;
+
+cd src
+nvcc -c -Dver=2 empty.cu;
+
+true;
+EOF
+chmod +x ${build_file}
+
+cat > "${root_dir}/expected.json" << EOF
+[
+{
+  "arguments": [
+    "nvcc",
+    "-c",
+    "-Dver=1",
+    "src/empty.cu"
+  ],
+  "directory": "${root_dir}",
+  "file": "src/empty.cu"
+},
+{
+  "arguments": [
+    "nvcc",
+    "-c",
+    "-Dver=2",
+    "empty.cu"
+  ],
+  "directory": "${root_dir}/src",
+  "file": "empty.cu"
+}
+]
+EOF

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -60,6 +60,8 @@ elif is_available('mingw32-make'):
 if is_available('gfortran'):
     config.available_features.add('fortran')
 
+if is_available('nvcc'):
+    config.available_features.add('cuda')
 
 # classify os script language
 is_windows = sys.platform in {'win32', 'cygwin'}


### PR DESCRIPTION
I noticed that `bear` does not add CUDA source files to `compile_commands.json`. Clang-based tools can understand CUDA (e.g. I use rtags for completion in `.cu` files), so it's useful to have these in the database.

I was able to fix this by recognizing `nvcc` as a C++ compiler and classifying `.cu` files as C++ sources.

I'm happy to add a test for this but I don't recognize the test system that you're using so I may need some help with that.