### PR TITLE
Fix Installation Issue

### DIFF
--- a/shell-completion/bash/CMakeLists.txt
+++ b/shell-completion/bash/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(bash-completion)
-if (NOT BASH_COMPLETION_FOUND)
+if (NOT BASH_COMPLETION_FOUND OR NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     # Fallback default dir
     set(BASH_COMPLETION_COMPLETIONSDIR
         "${CMAKE_INSTALL_DATADIR}/bash-completion/completions/")


### PR DESCRIPTION
Specifying the CMake variable `CMAKE_INSTALL_PREFIX` is causing erroneous behavior:
```bash
~/0EXTERNAL/git-repos/Bear/Release $ cmake -DCMAKE_INSTALL_PREFIX=/home/i/install -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_C_COMPILER=/home/i/install/bin/clang -DCMAKE_CXX_COMPILER=/home/i/install/bin/clang++ ..
-- The C compiler identification is Clang 9.0.1
-- Check for working C compiler: /home/i/install/bin/clang
-- Check for working C compiler: /home/i/install/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test C99_SUPPORTED
-- Performing Test C99_SUPPORTED - Success
-- Looking for execve
-- Looking for execve - found
-- Looking for execv
-- Looking for execv - found
-- Looking for execvpe
-- Looking for execvpe - found
-- Looking for execvp
-- Looking for execvp - found
-- Looking for execvP
-- Looking for execvP - not found
-- Looking for exect
-- Looking for exect - not found
-- Looking for execl
-- Looking for execl - found
-- Looking for execlp
-- Looking for execlp - found
-- Looking for execle
-- Looking for execle - found
-- Looking for posix_spawn
-- Looking for posix_spawn - found
-- Looking for posix_spawnp
-- Looking for posix_spawnp - found
-- Looking for _NSGetEnviron
-- Looking for _NSGetEnviron - not found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found PythonInterp: /usr/bin/python (found version "2.7.15") 
-- Looking for lit
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CXX_COMPILER


-- Build files have been written to: /home/i/0EXTERNAL/git-repos/Bear/Release
~/0EXTERNAL/git-repos/Bear/Release $ make -j1
Scanning dependencies of target ear
[ 50%] Building C object libear/CMakeFiles/ear.dir/ear.c.o
[100%] Linking C shared library libear.so
[100%] Built target ear
~/0EXTERNAL/git-repos/Bear/Release $ make install
[100%] Built target ear
Install the project...
-- Install configuration: "Release"
-- Up-to-date: /home/i/install/share/doc/bear/COPYING
-- Up-to-date: /home/i/install/share/doc/bear/README.md
-- Up-to-date: /home/i/install/share/doc/bear/ChangeLog.md
-- Installing: /home/i/install/lib/bear/libear.so
-- Installing: /home/i/install/bin/bear
-- Up-to-date: /home/i/install/share/man/man1/bear.1
-- Installing: /usr/share/bash-completion/completions/bear
CMake Error at shell-completion/bash/cmake_install.cmake:49 (file):
  file INSTALL cannot copy file
  "/home/i/0EXTERNAL/git-repos/Bear/shell-completion/bash/bear" to
  "/usr/share/bash-completion/completions/bear".
Call Stack (most recent call first):
  shell-completion/cmake_install.cmake:42 (include)
  cmake_install.cmake:54 (include)


Makefile:107: recipe for target 'install' failed
make: *** [install] Error 1
~/0EXTERNAL/git-repos/Bear/Release $ 
```

<hr>

This fix corrects said erroneous behavior:
```bash
~/0EXTERNAL/git-repos/Bear/Release $ cmake -DCMAKE_INSTALL_PREFIX=/home/i/install -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE -DCMAKE_C_COMPILER=/home/i/install/bin/clang -DCMAKE_CXX_COMPILER=/home/i/install/bin/clang++ ..
-- The C compiler identification is Clang 9.0.1
-- Check for working C compiler: /home/i/install/bin/clang
-- Check for working C compiler: /home/i/install/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test C99_SUPPORTED
-- Performing Test C99_SUPPORTED - Success
-- Looking for execve
-- Looking for execve - found
-- Looking for execv
-- Looking for execv - found
-- Looking for execvpe
-- Looking for execvpe - found
-- Looking for execvp
-- Looking for execvp - found
-- Looking for execvP
-- Looking for execvP - not found
-- Looking for exect
-- Looking for exect - not found
-- Looking for execl
-- Looking for execl - found
-- Looking for execlp
-- Looking for execlp - found
-- Looking for execle
-- Looking for execle - found
-- Looking for posix_spawn
-- Looking for posix_spawn - found
-- Looking for posix_spawnp
-- Looking for posix_spawnp - found
-- Looking for _NSGetEnviron
-- Looking for _NSGetEnviron - not found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found PythonInterp: /usr/bin/python (found version "2.7.15") 
-- Looking for lit
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CXX_COMPILER


-- Build files have been written to: /home/i/0EXTERNAL/git-repos/Bear/Release
~/0EXTERNAL/git-repos/Bear/Release $ make -j1
Scanning dependencies of target ear
[ 50%] Building C object libear/CMakeFiles/ear.dir/ear.c.o
[100%] Linking C shared library libear.so
[100%] Built target ear
~/0EXTERNAL/git-repos/Bear/Release $ make install
[100%] Built target ear
Install the project...
-- Install configuration: "Release"
-- Up-to-date: /home/i/install/share/doc/bear/COPYING
-- Up-to-date: /home/i/install/share/doc/bear/README.md
-- Installing: /home/i/install/share/doc/bear/ChangeLog.md
-- Installing: /home/i/install/lib/bear/libear.so
-- Installing: /home/i/install/bin/bear
-- Installing: /home/i/install/share/man/man1/bear.1
-- Installing: /home/i/install/share/bash-completion/completions/bear
~/0EXTERNAL/git-repos/Bear/Release $ 
```