### PR TITLE
add --remove-flags argument

### DIFF
--- a/test/functional/cases/end-to-end/qmake.ft
+++ b/test/functional/cases/end-to-end/qmake.ft
@@ -1,4 +1,5 @@
 # REQUIRES: make,qmake,preload
+# RUN: rm -rf %T/qmake_build
 # RUN: mkdir -p %T/qmake_build
 # RUN: cd %T/qmake_build; %{qmake} ../../Input/qmake.pro
 # RUN: cd %T/qmake_build; %{intercept-build} --cdb qmake.json %{make}


### PR DESCRIPTION
Hi,

When I use Bear to capture cross-platform builds, I encountered a flag (-mabi=...) that will cause clangd to fail. Therefore, I added a Bear argument to add custom filters for flags. Figured it could be useful for others as well. so here it is.