### PR TITLE
Don't cache the value of _NSGetEnviron on macOS

### DIFF
--- a/libear/ear.c
+++ b/libear/ear.c
@@ -54,7 +54,7 @@
 
 #if defined HAVE_NSGETENVIRON
 # include <crt_externs.h>
-static char **environ;
+#define environ (*_NSGetEnviron())
 #else
 extern char **environ;
 #endif
@@ -183,11 +183,6 @@ static void on_unload(void) {
 }
 
 static int mt_safe_on_load(void) {
-#ifdef HAVE_NSGETENVIRON
-    environ = *_NSGetEnviron();
-    if (0 == environ)
-        return 0;
-#endif
     // Capture current relevant environment variables
     return capture_env_t(&initial_env);
 }
@@ -531,7 +526,7 @@ static int write_report(int fd, char const *const argv[]) {
     return 0;
 }
 
-/* update environment assure that chilren processes will copy the desired
+/* updating the environment assures that child processes will copy the desired
  * behaviour */
 
 static int capture_env_t(bear_env_t *env) {


### PR DESCRIPTION
This should fix #215, hopefully. I've tested this using `bear --libear` with the new libear.dylib (which was quite convenient, but I'm unsure if that was something I was supposed to use) on a couple of projects and it seems to work OK for most cases, whereas it didn't work at all before. I did run into one issue when trying to pass address sanitizer flags to ld but I'm unsure if that's a problem with Bear or this particular project's Makefile, so I'll try to double check that tomorrow.