### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ Install dependencies from packages on Ubuntu 20.04
 
     apt-get install python cmake pkg-config
     apt-get install libfmt-dev libspdlog-dev nlohmann-json3-dev
-    apt-get install libgrpc++-dev protobuf-compiler-grpc
+    apt-get install libgrpc++-dev protobuf-compiler-grpc libssl-dev
 
 Install dependencies from packages from Brew
 


### PR DESCRIPTION
As #306 , add missing `libssl-dev` dependency on Ubuntu 20.04.
Thank you.