### PR TITLE
fix build error on rhel8

### DIFF
--- a/source/citnames/CMakeLists.txt
+++ b/source/citnames/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(citnames_json_a PUBLIC fmt::fmt)
 target_link_libraries(citnames_json_a PUBLIC spdlog::spdlog)
 target_link_libraries(citnames_json_a PRIVATE nlohmann_json::nlohmann_json)
 target_compile_options(citnames_json_a PRIVATE -fexceptions)
+target_link_libraries(citnames_json_a PUBLIC stdc++fs)
 
 # Create a static library, which is used for unit tests and the final shared library.
 add_library(citnames_a OBJECT
@@ -36,6 +37,7 @@ target_link_libraries(citnames_a PUBLIC report_a)
 target_link_libraries(citnames_a PUBLIC sys_a)
 target_link_libraries(citnames_a PUBLIC fmt::fmt)
 target_link_libraries(citnames_a PUBLIC spdlog::spdlog)
+target_link_libraries(citnames_a PUBLIC stdc++fs)
 
 # Create an executable from the sub projects.
 add_executable(citnames
@@ -54,6 +56,7 @@ target_link_libraries(citnames rpc_a)
 target_link_libraries(citnames fmt::fmt)
 target_link_libraries(citnames spdlog::spdlog)
 target_link_libraries(citnames nlohmann_json::nlohmann_json)
+target_link_libraries(citnames stdc++fs)
 
 include(GNUInstallDirs)
 install(TARGETS citnames

--- a/source/intercept/CMakeLists.txt
+++ b/source/intercept/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(intercept_a PUBLIC sys_a)
 target_link_libraries(intercept_a PUBLIC report_a)
 target_link_libraries(intercept_a PUBLIC result_a)
 target_link_libraries(intercept_a PUBLIC spdlog::spdlog)
+target_link_libraries(intercept_a PUBLIC stdc++fs)
 
 # Create an executable from the sub projects.
 add_executable(intercept
@@ -80,6 +81,7 @@ target_link_libraries(wrapper result_a)
 target_link_libraries(wrapper sys_a)
 target_link_libraries(wrapper rpc_a)
 target_link_libraries(wrapper spdlog::spdlog)
+target_link_libraries(wrapper stdc++fs)
 
 install(TARGETS wrapper
         RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/source/libsys/CMakeLists.txt
+++ b/source/libsys/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(sys_a PUBLIC ${CMAKE_DL_LIBS})
 target_link_libraries(sys_a PUBLIC result_a)
 target_link_libraries(sys_a PRIVATE fmt::fmt)
 target_link_libraries(sys_a PRIVATE spdlog::spdlog)
+target_link_libraries(sys_a PUBLIC stdc++fs)
 
 if (ENABLE_UNIT_TESTS)
     add_executable(sys_unit_test


### PR DESCRIPTION
**Describe the bug**
build error on rhel8

**To Reproduce**
Steps to reproduce the behavior:
```shell
cmake -DENABLE_UNIT_TESTS=OFF -DENABLE_FUNC_TESTS=OFF ..
make all
```

**Environment:**
 - OS name: Linux
 - OS version: Red Hat Enterprise Linux release 8.3
 - OS architecture: x86_64
 - gcc version: 8.3.1
 - Bear version: 3.0.7
 - Bear install method: from package

**Solution**
```
Adding target_link_libraries(<target> stdc++fs) to the list of link libraries in the CMakeLists.txt files 
on each target the linking was failing solved this.
```

**Output**
```
Scanning dependencies of target grpc_dependency
[  0%] Built target grpc_dependency
Scanning dependencies of target googletest_dependency
[  0%] Built target googletest_dependency
Scanning dependencies of target nlohmann_json_dependency
[  5%] Creating directories for 'nlohmann_json_dependency'
[ 11%] Performing download step (download, verify and extract) for 'nlohmann_json_dependency'
-- Downloading...
   dst='/root/source/Bear-3.0.7/build/subprojects/Download/nlohmann_json_dependency/v3.9.1.tar.gz'
   timeout='none'
   inactivity timeout='none'
-- Using src='https://github.com/nlohmann/json/archive/v3.9.1.tar.gz'
-- verifying file...
       file='/root/source/Bear-3.0.7/build/subprojects/Download/nlohmann_json_dependency/v3.9.1.tar.gz'
-- Downloading... done
-- extracting...
     src='/root/source/Bear-3.0.7/build/subprojects/Download/nlohmann_json_dependency/v3.9.1.tar.gz'
     dst='/root/source/Bear-3.0.7/build/subprojects/Source/nlohmann_json_dependency'
-- extracting... [tar xfz]
-- extracting... [analysis]
-- extracting... [rename]
-- extracting... [clean up]
-- extracting... done
[ 17%] No update step for 'nlohmann_json_dependency'
[ 23%] No patch step for 'nlohmann_json_dependency'
[ 29%] Performing configure step for 'nlohmann_json_dependency'
-- nlohmann_json_dependency configure command succeeded.  See also /root/source/Bear-3.0.7/build/subprojects/Stamp/nlohmann_json_dependency/nlohmann_json_dependency-configure-*.log
[ 35%] Performing build step for 'nlohmann_json_dependency'
-- nlohmann_json_dependency build command succeeded.  See also /root/source/Bear-3.0.7/build/subprojects/Stamp/nlohmann_json_dependency/nlohmann_json_dependency-build-*.log
[ 41%] Performing install step for 'nlohmann_json_dependency'
-- nlohmann_json_dependency install command succeeded.  See also /root/source/Bear-3.0.7/build/subprojects/Stamp/nlohmann_json_dependency/nlohmann_json_dependency-install-*.log
[ 47%] Completed 'nlohmann_json_dependency'
[ 47%] Built target nlohmann_json_dependency
Scanning dependencies of target fmt_dependency
[ 47%] Built target fmt_dependency
Scanning dependencies of target spdlog_dependency
[ 47%] Built target spdlog_dependency
Scanning dependencies of target BearSource
[ 52%] Creating directories for 'BearSource'
[ 58%] No download step for 'BearSource'
[ 64%] No update step for 'BearSource'
[ 70%] No patch step for 'BearSource'
[ 76%] Performing configure step for 'BearSource'
loading initial cache file /root/source/Bear-3.0.7/build/subprojects/tmp/BearSource/BearSource-cache-Release.cmake
-- The C compiler identification is GNU 8.3.1
-- The CXX compiler identification is GNU 8.3.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Found nlohmann_json: /root/source/Bear-3.0.7/build/subprojects/Install/nlohmann_json_dependency/lib64/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.9.1")
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.4.2")
-- Checking for modules 'protobuf;grpc++'
--   Found protobuf, version 3.11.2
--   Found grpc++, version 1.26.0
-- Checking for module 'sqlite3'
--   Found sqlite3, version 3.26.0
-- Looking for spawn.h
-- Looking for spawn.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for dlfcn.h
-- Looking for dlfcn.h - found
-- Looking for errno.h
-- Looking for errno.h - found
-- Looking for sys/utsname.h
-- Looking for sys/utsname.h - found
-- Looking for sys/wait.h
-- Looking for sys/wait.h - found
-- Looking for gnu/lib-names.h
-- Looking for gnu/lib-names.h - found
-- Looking for _NSGetEnviron
-- Looking for _NSGetEnviron - not found
-- Looking for dlopen
-- Looking for dlopen - found
-- Looking for dlsym
-- Looking for dlsym - found
-- Looking for dlerror
-- Looking for dlerror - found
-- Looking for dlclose
-- Looking for dlclose - found
-- Looking for RTLD_NEXT
-- Looking for RTLD_NEXT - found
-- Looking for EACCES
-- Looking for EACCES - found
-- Looking for ENOENT
-- Looking for ENOENT - found
-- Looking for strerror_r
-- Looking for strerror_r - found
-- Looking for environ
-- Looking for environ - found
-- Looking for uname
-- Looking for uname - found
-- Looking for confstr
-- Looking for confstr - found
-- Looking for _CS_PATH
-- Looking for _CS_PATH - found
-- Looking for _CS_GNU_LIBC_VERSION
-- Looking for _CS_GNU_LIBC_VERSION - found
-- Looking for _CS_GNU_LIBPTHREAD_VERSION
-- Looking for _CS_GNU_LIBPTHREAD_VERSION - found
-- Looking for protoc ... /usr/bin/protoc
-- Looking for grpc_cpp_plugin ... /usr/bin/grpc_cpp_plugin
-- Configuring done
-- Generating done
-- Build files have been written to: /root/source/Bear-3.0.7/build/subprojects/Build/BearSource
[ 82%] Performing build step for 'BearSource'
Scanning dependencies of target flags_a
[  1%] Building CXX object libflags/CMakeFiles/flags_a.dir/source/Flags.cc.o
[  1%] Built target flags_a
Scanning dependencies of target shell_a
[  3%] Building CXX object libshell/CMakeFiles/shell_a.dir/source/Command.cc.o
[  3%] Built target shell_a
Scanning dependencies of target sys_a
[  5%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Os.cc.o
[  6%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Guard.cc.o
[  8%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Errors.cc.o
[ 10%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Path.cc.o
[ 11%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Process.cc.o
[ 13%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Signal.cc.o
[ 13%] Built target sys_a
Scanning dependencies of target main_a
[ 15%] Building CXX object libmain/CMakeFiles/main_a.dir/source/ApplicationLogConfig.cc.o
[ 16%] Building CXX object libmain/CMakeFiles/main_a.dir/source/ApplicationFromArgs.cc.o
[ 16%] Built target main_a
[ 18%] Generating supervise.pb.h, supervise.grpc.pb.h, supervise.pb.cc, supervise.grpc.pb.cc
[ 20%] Generating intercept.pb.h, intercept.grpc.pb.h, intercept.pb.cc, intercept.grpc.pb.cc
Scanning dependencies of target rpc_a
[ 21%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/supervise.pb.cc.o
[ 23%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/supervise.grpc.pb.cc.o
[ 25%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/intercept.pb.cc.o
[ 26%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/intercept.grpc.pb.cc.o
[ 26%] Built target rpc_a
Scanning dependencies of target report_a
[ 28%] Building CXX object intercept/CMakeFiles/report_a.dir/source/collect/EventsDatabase.cc.o
[ 28%] Built target report_a
Scanning dependencies of target exec_a
[ 30%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Buffer.cc.o
[ 31%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Environment.cc.o
[ 33%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Executor.cc.o
[ 35%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Linker.cc.o
[ 36%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Logger.cc.o
[ 38%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Paths.cc.o
[ 40%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Resolver.cc.o
[ 41%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Session.cc.o
[ 41%] Built target exec_a
Scanning dependencies of target intercept_a
[ 43%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Application.cc.o
[ 45%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Reporter.cc.o
[ 46%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Services.cc.o
[ 48%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Session.cc.o
[ 50%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/SessionWrapper.cc.o
[ 51%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/SessionLibrary.cc.o
[ 51%] Built target intercept_a
Scanning dependencies of target reporter_a
[ 53%] Building CXX object intercept/CMakeFiles/reporter_a.dir/source/report/EventFactory.cc.o
[ 55%] Building CXX object intercept/CMakeFiles/reporter_a.dir/source/report/InterceptClient.cc.o
[ 55%] Built target reporter_a
Scanning dependencies of target wrapper
[ 56%] Building CXX object intercept/CMakeFiles/wrapper.dir/source/report/wrapper/Application.cc.o
/root/source/Bear-3.0.7/source/intercept/source/report/wrapper/Application.cc: In member function ‘virtual rust::Result<std::unique_ptr<ps::Command> > wr::Application::command(int, const char**, const char**) const’:
/root/source/Bear-3.0.7/source/intercept/source/report/wrapper/Application.cc:126:59: warning: unused parameter ‘argc’ [-Wunused-parameter]
     rust::Result<ps::CommandPtr> Application::command(int argc, const char **argv, const char **envp) const {
                                                       ~~~~^~~~
[ 58%] Building CXX object intercept/CMakeFiles/wrapper.dir/source/report/wrapper/main.cc.o
[ 60%] Linking CXX executable wrapper
CMakeFiles/wrapper.dir/source/report/wrapper/Application.cc.o: In function `std::_Function_handler<rust::Result<sys::Process, std::runtime_error> (rpc::ExecutionContext const&), wr::Command::execute() const::{lambda(auto:1)#2}>::_M_invoke(std::_Any_data const&, rpc::ExecutionContext const&)':
Application.cc:(.text+0xfc4): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
CMakeFiles/wrapper.dir/source/report/wrapper/Application.cc.o: In function `wr::Command::execute() const':
Application.cc:(.text+0x2dbf): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
CMakeFiles/wrapper.dir/source/report/wrapper/Application.cc.o: In function `wr::Application::command(int, char const**, char const**) const':
Application.cc:(.text+0x3ed0): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
../libsys/CMakeFiles/sys_a.dir/source/Process.cc.o: In function `sys::Process::Builder::Builder(std::filesystem::__cxx11::path)':
Process.cc:(.text+0x4b0): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
Process.cc:(.text+0x504): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
../libsys/CMakeFiles/sys_a.dir/source/Path.cc.o:Path.cc:(.text+0x1f3): more undefined references to `std::filesystem::__cxx11::path::_M_split_cmpts()' follow
../libsys/CMakeFiles/sys_a.dir/source/Path.cc.o: In function `sys::path::get_cwd[abi:cxx11]()':
Path.cc:(.text+0xd61): undefined reference to `std::filesystem::current_path[abi:cxx11](std::error_code&)'
Path.cc:(.text+0x1039): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
Path.cc:(.text+0x10d9): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
Path.cc:(.text+0x11ad): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
Path.cc:(.text+0x11c9): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
collect2: error: ld returned 1 exit status
make[5]: *** [intercept/CMakeFiles/wrapper.dir/build.make:159: intercept/wrapper] Error 1
make[4]: *** [CMakeFiles/Makefile2:469: intercept/CMakeFiles/wrapper.dir/all] Error 2
make[3]: *** [Makefile:149: all] Error 2
make[2]: *** [CMakeFiles/BearSource.dir/build.make:134: subprojects/Stamp/BearSource/BearSource-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:222: CMakeFiles/BearSource.dir/all] Error 2
make: *** [Makefile:171: all] Error 2
```
