### PR TITLE
default LIBDIR for Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,17 @@ include(ExternalProject)
 set_property(DIRECTORY PROPERTY EP_BASE ${CMAKE_BINARY_DIR}/subprojects)
 set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/stage)
 set(DEPENDENCIES_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/subprojects/Install)
+# check if CMAKE_INSTALL_LIBDIR is set before GNUInstallDirs sets it
+get_property(bear_libdir_set CACHE CMAKE_INSTALL_LIBDIR PROPERTY TYPE SET)
 include(GNUInstallDirs)
+
+# Default LIBDIR for Debian systems
+if (NOT bear_libdir_set)
+    if (EXISTS "/etc/debian_version" AND CMAKE_LIBRARY_ARCHITECTURE)
+        set_property(CACHE CMAKE_INSTALL_LIBDIR PROPERTY VALUE 
+                "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    endif()
+endif()
 
 # Verify or install dependencies
 add_subdirectory(third_party)


### PR DESCRIPTION
Thanks for the answer in #409 I had missed the updated Install instructions

For Debian systems would you be opposed to something like this as it seems unlikely to get fixed upstream anytime soon? https://gitlab.kitware.com/cmake/cmake/-/issues/20565

I would assume most people are not going to be installing into `/usr` so for Debian based systems most people won't get the right LIBDIR without reading your Install.md