### PR TITLE
Fix #469: set errno to 0 after libexec's on_load

### DIFF
--- a/source/intercept/source/report/libexec/lib.cc
+++ b/source/intercept/source/report/libexec/lib.cc
@@ -111,6 +111,7 @@ extern "C" void on_load()
     el::log::set(level);
 
     LOGGER.debug("on_load");
+    errno = 0;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/rizsotto/Bear/issues/469

This simply sets `errno = 0` at the end of libexec.so's `on_load`