### PR TITLE
Fix undefined __cxxabiv1::__class_type_info vtable

### DIFF
--- a/source/intercept/CMakeLists.txt
+++ b/source/intercept/CMakeLists.txt
@@ -180,7 +180,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set_target_properties(exec PROPERTIES
-            LINKER_LANGUAGE "C"
+            LINKER_LANGUAGE "CXX"
             OSX_ARCHITECTURES:STRING "i386;x86_64"
             MACOSX_RPATH:BOOL ON
             )


### PR DESCRIPTION
Linking C++ code with the C linker causes a missing vtable for in __cxxabiv1::__class_type_info, referenced from runtime type information in el::Linker and el::Resolver. Linking this library with clang++ instead fixes the issue.

From the git log, it was not clear to me why LINKER_LANGUAGE "C" was introduced in the first place. It no longer seems to be necessary.

Full error is:

```
/usr/bin/clang  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -mmacosx-version-min=12.0 -dynamiclib -Wl,-headerpad_max_install_names -o libexec.dylib -install_name @rpath/libexec.dylib CMakeFiles/exec.dir/source/report/libexec/lib.cc.o CMakeFiles/exec.dir/source/report/libexec/std.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Buffer.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Environment.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Executor.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Linker.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Logger.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Paths.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Resolver.cc.o CMakeFiles/exec_a.dir/source/report/libexec/Session.cc.o
Undefined symbols for architecture arm64:
  "vtable for __cxxabiv1::__class_type_info", referenced from:
      typeinfo for el::Linker in Linker.cc.o
      typeinfo for el::Resolver in Resolver.cc.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

`/usr/bin/clang` is
```
$ /usr/bin/clang -v
Apple clang version 13.1.6 (clang-1316.0.21.2.5)
Target: arm64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```