### PR TITLE
add -DCMAKE_PROJECT_INCLUDE argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ include(GNUInstallDirs)
 # Verify or install dependencies
 add_subdirectory(third_party)
 
+unset(CMAKE_CACHE_ARGS_EXTRA)
+if (CMAKE_PROJECT_INCLUDE AND NOT CMAKE_PROJECT_INCLUDE STREQUAL "")
+    set(CMAKE_CACHE_ARGS_EXTRA "-DCMAKE_PROJECT_INCLUDE:PATH=${CMAKE_PROJECT_INCLUDE}")
+endif()
+
 # Build the project itself
 ExternalProject_Add(BearSource
         SOURCE_DIR
@@ -69,6 +74,7 @@ ExternalProject_Add(BearSource
             -DCMAKE_INSTALL_LIBDIR:PATH=${CMAKE_INSTALL_LIBDIR}
             -DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}
             -DROOT_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+            ${CMAKE_CACHE_ARGS_EXTRA}
         TEST_BEFORE_INSTALL
             1
         TEST_COMMAND


### PR DESCRIPTION
close #479

add -DCMAKE_PROJECT_INCLUDE argument to allow user injecting custom code into source subproject without modifying it's source code.

for example, user may want to link static libraries, they can write following code to `project-after.cmake`
```
set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
```

then pass `-DCMAKE_PROJECT_INCLUDE=project-after.cmake` to cmake command

then project-after.cmake will be automatically run after `project()` command

Reference: https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_INCLUDE.html

Signed-off-by: leleliu008 <leleliu008@gmail.com>