### PR TITLE
libsys: Add functions to read the environment variables without passing envp

### DIFF
--- a/source/bear/source/Application.cc
+++ b/source/bear/source/Application.cc
@@ -197,7 +197,7 @@ namespace bear {
 				})
 				.unwrap_or(fs::path(cmd::citnames::DEFAULT_OUTPUT));
 
-		auto environment = sys::env::from(const_cast<const char **>(envp));
+		const auto& environment = sys::env::get();
 		auto intercept = prepare_intercept(args, environment, commands);
 		auto citnames = prepare_citnames(args, environment, commands);
 

--- a/source/citnames/source/Citnames.cc
+++ b/source/citnames/source/Citnames.cc
@@ -229,7 +229,7 @@ namespace cs {
     { }
 
     rust::Result<ps::CommandPtr> Citnames::command(const flags::Arguments &args, const char **envp) const {
-        auto environment = sys::env::from(const_cast<const char **>(envp));
+        const auto& environment = sys::env::get();
 
         auto arguments = into_arguments(args);
         auto configuration = into_configuration(args, environment);

--- a/source/intercept/source/collect/Intercept.cc
+++ b/source/intercept/source/collect/Intercept.cc
@@ -38,7 +38,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
-    rust::Result<ic::Execution> capture_execution(const flags::Arguments& args, sys::env::Vars &&environment)
+    rust::Result<ic::Execution> capture_execution(const flags::Arguments& args, const sys::env::Vars &environment)
     {
         const auto path = sys::os::get_path(environment);
 
@@ -110,7 +110,7 @@ namespace ic {
     { }
 
     rust::Result<ps::CommandPtr> Intercept::command(const flags::Arguments &args, const char **envp) const {
-        const auto execution = capture_execution(args, sys::env::from(envp));
+        const auto execution = capture_execution(args, sys::env::get());
         const auto session = Session::from(args, envp);
         const auto reporter = Reporter::from(args);
 

--- a/source/intercept/source/report/wrapper/Application.cc
+++ b/source/intercept/source/report/wrapper/Application.cc
@@ -84,7 +84,7 @@ namespace {
             return {argv, end};
         }
 
-        rust::Result<wr::Execution> make_execution(const char **argv, sys::env::Vars &&environment) noexcept
+        rust::Result<wr::Execution> make_execution(const char **argv, const sys::env::Vars &environment) noexcept
         {
             auto program = fs::path(argv[0]);
             auto arguments = from(argv);
@@ -105,7 +105,7 @@ namespace {
                     });
         }
 
-        rust::Result<wr::Execution> make_execution(const flags::Arguments &args, sys::env::Vars &&environment) noexcept {
+        rust::Result<wr::Execution> make_execution(const flags::Arguments &args, const sys::env::Vars &environment) noexcept {
             auto program = args.as_string(cmd::wrapper::FLAG_EXECUTE)
                     .map<fs::path>([](auto file) { return fs::path(file); });
             auto arguments = args.as_string_list(cmd::wrapper::FLAG_COMMAND)
@@ -201,9 +201,9 @@ namespace wr {
     }
 
     rust::Result<ps::CommandPtr> Application::from_envs(int, const char **argv, const char **envp) {
-        auto environment = sys::env::from(const_cast<const char **>(envp));
+        const auto& environment = sys::env::get();
         auto session = Wrapper::make_session(environment);
-        auto execution = Wrapper::make_execution(argv, std::move(environment));
+        auto execution = Wrapper::make_execution(argv, environment);
 
         return rust::merge(session, execution)
                 .map<ps::CommandPtr>([](const auto &tuple) {
@@ -213,7 +213,7 @@ namespace wr {
     }
 
     rust::Result<ps::CommandPtr> Application::from_args(const flags::Arguments &args, const char **envp) {
-        auto environment = sys::env::from(const_cast<const char **>(envp));
+        const auto& environment = sys::env::get();
         auto session = Supervisor::make_session(args);
         auto execution = Supervisor::make_execution(args, std::move(environment));
 

--- a/source/libsys/include/libsys/Environment.h
+++ b/source/libsys/include/libsys/Environment.h
@@ -26,6 +26,12 @@ namespace sys::env {
 
     using Vars = std::map<std::string, std::string>;
 
+    // Get environment variables
+    const Vars& get();
+
+    // Get environment variables as C-Style array
+    const char** get_envp();
+
     // Convert an environment array into a map.
     Vars from(const char** value);
 }

--- a/source/libsys/test/EnvironmentTest.cc
+++ b/source/libsys/test/EnvironmentTest.cc
@@ -112,4 +112,11 @@ namespace {
         EXPECT_STREQ(sut.data()[1], "sky=blue");
         EXPECT_TRUE(sut.data()[2] == nullptr);
     }
+    
+    TEST(environment, env_get) {
+        auto result = sys::env::get();
+        auto reference = sys::env::from(sys::env::get_envp());
+
+        EXPECT_EQ(result, reference);
+    }
 }


### PR DESCRIPTION
The functions `sys::env::get` and `sys::env::get_envp` allow to read the environment vars directly from the `environ` extern and it will allow to remove all the envp arguments passed to functions.