### PR TITLE
Avoid implicit function declarations in tests, for C99 compatibility

### DIFF
--- a/test/cases/intercept/preload/errno_reset.c
+++ b/test/cases/intercept/preload/errno_reset.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#include <stdio.h>
 
 int main()
 {

--- a/test/cases/intercept/preload/posix/execvpe/success.c
+++ b/test/cases/intercept/preload/posix/execvpe/success.c
@@ -8,6 +8,7 @@
 #include "config.h"
 
 #if defined HAVE_UNISTD_H
+#define _GNU_SOURCE
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Include <stdio.h> for printf and define _GNU_SOURCE for execvpe.

Future compilers will not support implicit function declartions by default, causing these tests to fail to build.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
