### PR TITLE
dependency: fix fmt 10.0.0 incompatibilities

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(spdlog REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(gRPC REQUIRED IMPORTED_TARGET protobuf grpc++)
 
-if (fmt_VERSION_MAJOR EQUAL 9)
+if (fmt_VERSION_MAJOR GREATER_EQUAL 9)
     set(FMT_NEEDS_OSTREAM_FORMATTER 1)
     set(HAVE_FMT_STD_H 1) # FIXME: this should be done with `check_include_file`
 endif ()


### PR DESCRIPTION
Facing the bug same as #471 on fmt-10.0.0 version, do a quick fix.
gentoo downstream bug report: https://bugs.gentoo.org/906082