### PR TITLE
Add missing <algorithm> include for std::find

### DIFF
--- a/source/citnames/source/semantic/ToolAny.cc
+++ b/source/citnames/source/semantic/ToolAny.cc
@@ -19,6 +19,8 @@
 
 #include "ToolAny.h"
 
+#include <algorithm>
+
 namespace cs::semantic {
 
     ToolAny::ToolAny(ToolAny::ToolPtrs &&tools, std::list<fs::path> &&to_exclude) noexcept

--- a/source/citnames/source/semantic/ToolExtendingWrapper.cc
+++ b/source/citnames/source/semantic/ToolExtendingWrapper.cc
@@ -19,6 +19,8 @@
 
 #include "ToolExtendingWrapper.h"
 
+#include <algorithm>
+
 namespace cs::semantic {
 
     ToolExtendingWrapper::ToolExtendingWrapper(CompilerWrapper &&compilers_to_recognize) noexcept

--- a/source/libflags/source/Flags.cc
+++ b/source/libflags/source/Flags.cc
@@ -19,6 +19,7 @@
 
 #include "libflags/Flags.h"
 
+#include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <optional>

--- a/source/libsys/source/Guard.cc
+++ b/source/libsys/source/Guard.cc
@@ -20,6 +20,7 @@
 #include "Guard.h"
 #include "libsys/Environment.h"
 
+#include <algorithm>
 #include <cstring>
 #include <functional>
 

--- a/source/libsys/source/Process.cc
+++ b/source/libsys/source/Process.cc
@@ -22,6 +22,7 @@
 #include "libsys/Errors.h"
 #include "Guard.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <csignal>
 #include <cstdlib>


### PR DESCRIPTION
GCC 14 drops some transitive includes within libstdc++.

Explicitly include <algorithm> for std::find.