### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ project(Bear
         LANGUAGES C CXX
         )
 
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 option(ENABLE_UNIT_TESTS "Build and run unit test for this project" ON)
 option(ENABLE_FUNC_TESTS "Build and run functional test for this project" ON)
 option(ENABLE_MULTILIB "Enable to build with multilib support" OFF)


### PR DESCRIPTION
Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24 and newer