### PR TITLE
Use fmt/std to format std::path

### DIFF
--- a/source/citnames/source/semantic/Semantic.cc
+++ b/source/citnames/source/semantic/Semantic.cc
@@ -20,12 +20,7 @@
 #include "semantic/Semantic.h"
 
 #include <fmt/format.h>
-
-namespace fmt {
-
-    template <>
-    struct formatter<fs::path> : formatter<std::string> {};
-}
+#include <fmt/std.h>
 
 namespace cs::semantic {
 


### PR DESCRIPTION
Fixes https://github.com/rizsotto/Bear/issues/542

`fmt` supports formatting `fs::path` through `fmt/std.h`.