### PR TITLE
development/Bear: Updated for version 3.1.4 fix #566 upstream

### DIFF
--- a/source/intercept/source/collect/db/EventsDatabaseWriter.cc
+++ b/source/intercept/source/collect/db/EventsDatabaseWriter.cc
@@ -36,7 +36,6 @@ namespace {
     JsonPrintOptions create_print_options() {
         JsonPrintOptions print_options;
         print_options.add_whitespace = false;
-        print_options.always_print_primitive_fields = true;
         print_options.preserve_proto_field_names = true;
         print_options.always_print_enums_as_ints = false;
         return print_options;


### PR DESCRIPTION
New protobuf3-26.0 dependency for Bear causes the error:

```
[ 35%] Building CXX object intercept/CMakeFiles/events_db_a.dir/source/collect/db/EventsDatabaseWriter.cc.o
/tmp/SBo/Bear-3.1.3/source/intercept/source/collect/db/EventsDatabaseWriter.cc: In function ‘google::protobuf::util::JsonPrintOptions {anonymous}::create_print_options()’:
/tmp/SBo/Bear-3.1.3/source/intercept/source/collect/db/EventsDatabaseWriter.cc:39:23: error: ‘using JsonPrintOptions = struct google::protobuf::json::PrintOptions’ {aka ‘struct google::protobuf::json::PrintOptions’} has no member named ‘always_print_primitive_fields’
   39 |         print_options.always_print_primitive_fields = true;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[5]: *** [intercept/CMakeFiles/events_db_a.dir/build.make:90: intercept/CMakeFiles/events_db_a.dir/source/collect/db/EventsDatabaseWriter.cc.o] Error 1
make[4]: *** [CMakeFiles/Makefile2:388: intercept/CMakeFiles/events_db_a.dir/all] Error 2
make[3]: *** [Makefile:136: all] Error 2
make[2]: *** [CMakeFiles/BearSource.dir/build.make:87: subprojects/Stamp/BearSource/BearSource-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:174: CMakeFiles/BearSource.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```


