### PR TITLE
citnames: include fmt/ranges.h for using fmt::join()

### DIFF
--- a/source/citnames/source/semantic/Parsers.h
+++ b/source/citnames/source/semantic/Parsers.h
@@ -30,6 +30,7 @@
 #include <optional>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace cs::semantic {
 

--- a/source/citnames/source/semantic/Semantic.cc
+++ b/source/citnames/source/semantic/Semantic.cc
@@ -21,6 +21,7 @@
 #include "semantic/Semantic.h"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #ifdef HAVE_FMT_STD_H
 #include <fmt/std.h>
 #else


### PR DESCRIPTION
fmt::join() was moved into fmt/ranges.h since fmt v11, so include this header for using fmt::join(). otherwise, we'd have following compilation failure when building Bear with fmt v11 and up:

```
/builddir/build/BUILD/bear-3.1.4-build/Bear-3.1.4/source/citnames/source/semantic/Parsers.h:255:73: error: ‘join’ is not a member of ‘fmt’
  255 |                             fmt::format("Failed to recognize: {}", fmt::join(remainder.begin(), remainder.end(), ", "))
      |                                                                         ^~~~
```