### PR TITLE
ci: run alpine image against aarch64

### DIFF
--- a/.github/workflows/build_on_arch.yml
+++ b/.github/workflows/build_on_arch.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: fedora_latest
+            distro: alpine_latest
           - arch: s390x
             distro: alpine_latest
           - arch: ppc64le


### PR DESCRIPTION
fixing aarch64 builds.