### PR TITLE
citnames: allow pre/postfixes to cc & c++ compiler calls

### DIFF
--- a/source/citnames/source/semantic/ToolGcc.cc
+++ b/source/citnames/source/semantic/ToolGcc.cc
@@ -251,14 +251,13 @@ namespace cs::semantic {
 
     bool ToolGcc::is_compiler_call(const fs::path& program) const {
         static const auto pattern = std::regex(
-                // - cc
-                // - c++
                 // - cxx
                 // - CC
-                // - mcc, gcc, m++, g++, gfortran, fortran
+                // - cc, mcc, gcc, c++, m++, g++, gfortran, fortran
                 //   - with prefixes like: arm-none-eabi-
                 //   - with postfixes like: -7.0 or 6.4.0
-            R"(^(cc|c\+\+|cxx|CC|(([^-]*-)*([mg](cc|\+\+)|[g]?fortran)(-?\d+(\.\d+){0,2})?))$)"
+                // - (excluding cc1)
+            R"(^(cxx|CC|(([^-]*-)*(cc(?!1(?![\d\.]))|[mg]cc|[cmg]\+\+|[g]?fortran)(-?\d+(\.\d+){0,2})?))$)"
         );
 
         std::cmatch m;

--- a/source/citnames/test/ToolGccTest.cc
+++ b/source/citnames/test/ToolGccTest.cc
@@ -34,10 +34,13 @@ namespace {
 
         EXPECT_TRUE(sut.is_compiler_call("cc"));
         EXPECT_TRUE(sut.is_compiler_call("/usr/bin/cc"));
+        EXPECT_TRUE(sut.is_compiler_call("x86_64-pc-linux-gnu-cc"));
+        EXPECT_FALSE(sut.is_compiler_call("cc1"));
         EXPECT_TRUE(sut.is_compiler_call("gcc"));
         EXPECT_TRUE(sut.is_compiler_call("/usr/bin/gcc"));
         EXPECT_TRUE(sut.is_compiler_call("c++"));
         EXPECT_TRUE(sut.is_compiler_call("/usr/bin/c++"));
+        EXPECT_TRUE(sut.is_compiler_call("x86_64-pc-linux-gnu-c++"));
         EXPECT_TRUE(sut.is_compiler_call("g++"));
         EXPECT_TRUE(sut.is_compiler_call("/usr/bin/g++"));
         EXPECT_TRUE(sut.is_compiler_call("arm-none-eabi-g++"));


### PR DESCRIPTION
This pull request modifies the regex for recognized GCC compiler calls to allow pre/postfixes to `cc` and `c++` in the same manner as already implemented e.g. for `gcc` (though explicitly excluding `cc1`, which otherwise would also be matched). This matches e.g. the previously missing `x86_64-pc-linux-gnu-cc` and `x86_64-pc-linux-gnu-c++` compiler calls that are present on my system (Gentoo, sys-devel/gcc-13.2.1_p20240210).

More specifically, I've encountered the issue of such compiler call being unrecognized when applying Bear to the compilation of Neomutt and using the `.configure` command as used by portage for the Neomutt ebuild (to align with target build process), which then employs `x86_64-pc-linux-gnu-cc` as compiler call. While this is simply a symlink to `x86_64-pc-linux-gnu-gcc` (which is recognized by Bear) and the alternative solution would of course be to modify the employed `.configure` command so that `make` uses a "different" (but actually identical) compiler call, it would make sense to me if Bear simply recognizes such compiler calls as well (not having used Bear before, it took me a bit to figure out why the generated `compile_commands.json` was almost empty).