### PR TITLE
Replace lazy_static with OnceLock

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,6 @@ resolver = "2"
 [workspace.dependencies]
 thiserror = "1.0"
 anyhow = "1.0"
-lazy_static = { version = "1.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_yml = "0.0"

--- a/rust/bear/Cargo.toml
+++ b/rust/bear/Cargo.toml
@@ -26,7 +26,6 @@ path = "src/bin/wrapper.rs"
 [dependencies]
 thiserror.workspace = true
 anyhow.workspace = true
-lazy_static.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yml.workspace = true

--- a/rust/bear/src/semantic/interpreters/gcc.rs
+++ b/rust/bear/src/semantic/interpreters/gcc.rs
@@ -43,7 +43,6 @@ impl Interpreter for Gcc {
 }
 
 mod internal {
-    use lazy_static::lazy_static;
     use nom::{error::ErrorKind, IResult};
     use regex::Regex;
     use std::path::PathBuf;
@@ -194,7 +193,7 @@ mod internal {
         todo!()
     }
 
-    lazy_static! {
+    static COMPILER_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
         // - cc
         // - c++
         // - cxx
@@ -202,8 +201,9 @@ mod internal {
         // - mcc, gcc, m++, g++, gfortran, fortran
         //   - with prefixes like: arm-none-eabi-
         //   - with postfixes like: -7.0 or 6.4.0
-        static ref COMPILER_REGEX: Regex = Regex::new(
-            r"(^(cc|c\+\+|cxx|CC|(([^-]*-)*([mg](cc|\+\+)|[g]?fortran)(-?\d+(\.\d+){0,2})?))$)"
-        ).unwrap();
-    }
+        Regex::new(
+            r"(^(cc|c\+\+|cxx|CC|(([^-]*-)*([mg](cc|\+\+)|[g]?fortran)(-?\d+(\.\d+){0,2})?))$)",
+        )
+        .unwrap()
+    });
 }

--- a/rust/bear/src/semantic/interpreters/generic.rs
+++ b/rust/bear/src/semantic/interpreters/generic.rs
@@ -64,8 +64,6 @@ impl Interpreter for Generic {
 mod test {
     use std::collections::HashMap;
 
-    use lazy_static::lazy_static;
-
     use crate::{vec_of_pathbuf, vec_of_strings};
 
     use super::*;
@@ -126,9 +124,7 @@ mod test {
         assert_eq!(Recognition::Unknown, SUT.recognize(&input));
     }
 
-    lazy_static! {
-        static ref SUT: Generic = Generic {
-            executables: vec_of_pathbuf!["/usr/bin/something"].into_iter().collect()
-        };
-    }
+    static SUT: std::sync::LazyLock<Generic> = std::sync::LazyLock::new(|| Generic {
+        executables: vec_of_pathbuf!["/usr/bin/something"].into_iter().collect(),
+    });
 }

--- a/rust/bear/src/semantic/interpreters/matchers/source.rs
+++ b/rust/bear/src/semantic/interpreters/matchers/source.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use lazy_static::lazy_static;
 use std::collections::HashSet;
 
 #[cfg(target_family = "unix")]
@@ -27,39 +26,38 @@ pub fn looks_like_a_source_file(argument: &str) -> bool {
     false
 }
 
-lazy_static! {
-    static ref EXTENSIONS: HashSet<&'static str> = {
-        HashSet::from([
-            // header files
-            "h", "hh", "H", "hp", "hxx", "hpp", "HPP", "h++", "tcc",
-            // C
-            "c", "C",
-            // C++
-            "cc", "CC", "c++", "C++", "cxx", "cpp", "cp",
-            // CUDA
-            "cu",
-            // ObjectiveC
-            "m", "mi", "mm", "M", "mii",
-            // Preprocessed
-            "i", "ii",
-            // Assembly
-            "s", "S", "sx", "asm",
-            // Fortran
-            "f", "for", "ftn",
-            "F", "FOR", "fpp", "FPP", "FTN",
-            "f90", "f95", "f03", "f08",
-            "F90", "F95", "F03", "F08",
-            // go
-            "go",
-            // brig
-            "brig",
-            // D
-            "d", "di", "dd",
-            // Ada
-            "ads", "abd"
-        ])
-    };
-}
+#[rustfmt::skip]
+static EXTENSIONS: std::sync::LazyLock<HashSet<&'static str>> = std::sync::LazyLock::new(|| {
+    HashSet::from([
+        // header files
+        "h", "hh", "H", "hp", "hxx", "hpp", "HPP", "h++", "tcc",
+        // C
+        "c", "C",
+        // C++
+        "cc", "CC", "c++", "C++", "cxx", "cpp", "cp",
+        // CUDA
+        "cu",
+        // ObjectiveC
+        "m", "mi", "mm", "M", "mii",
+        // Preprocessed
+        "i", "ii",
+        // Assembly
+        "s", "S", "sx", "asm",
+        // Fortran
+        "f", "for", "ftn",
+        "F", "FOR", "fpp", "FPP", "FTN",
+        "f90", "f95", "f03", "f08",
+        "F90", "F95", "F03", "F08", 
+        // go
+        "go",  
+        // brig
+        "brig",
+        // D
+        "d", "di", "dd",
+        // Ada
+        "ads", "abd",
+    ])
+});
 
 #[cfg(test)]
 mod test {

--- a/rust/bear/tests/intercept.rs
+++ b/rust/bear/tests/intercept.rs
@@ -7,7 +7,6 @@ use bear::intercept::*;
 mod test {
     use super::*;
     use crossbeam_channel::bounded;
-    use lazy_static::lazy_static;
     use std::collections::HashMap;
     use std::io::Cursor;
     use std::path::PathBuf;
@@ -77,8 +76,8 @@ mod test {
         }
     }
 
-    lazy_static! {
-        static ref ENVELOPES: Vec<Envelope> = vec![
+    static ENVELOPES: std::sync::LazyLock<Vec<Envelope>> = std::sync::LazyLock::new(|| {
+        vec![
             Envelope {
                 rid: ReporterId::new(),
                 timestamp: fixtures::timestamp(),
@@ -124,9 +123,11 @@ mod test {
                     },
                 },
             },
-        ];
-        static ref EVENTS: Vec<Event> = ENVELOPES.iter().map(|e| e.event.clone()).collect();
-    }
+        ]
+    });
+
+    static EVENTS: std::sync::LazyLock<Vec<Event>> =
+        std::sync::LazyLock::new(|| ENVELOPES.iter().map(|e| e.event.clone()).collect());
 }
 
 mod fixtures {


### PR DESCRIPTION
Hello, I am glad to know that bear is being rewritten in Rust and it sounds interesting.
This patch removes uses of lazy_static since it is going to be deprecated (see https://github.com/rust-lang-nursery/lazy-static.rs/issues/214). The std library now supports OnceCell and OnceLock as alternatives.