### PR TITLE
Add `BUILD_ALWAYS` to ensure `BearSource` rebuilds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ ExternalProject_Add(BearSource
             -DCMAKE_MODULE_LINKER_FLAGS:STRING=${CMAKE_MODULE_LINKER_FLAGS}
             -DROOT_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
             ${CMAKE_CACHE_ARGS_EXTRA}
+        BUILD_ALWAYS
+            1
         TEST_BEFORE_INSTALL
             1
         TEST_COMMAND


### PR DESCRIPTION
This change ensures that `BearSource` is rebuilt whenever its sources are modified. The `BUILD_ALWAYS` option in CMake's `ExternalProject` module enforces this behavior. For more details, see the CMake documentation
https://cmake.org/cmake/help/latest/module/ExternalProject.html.