### PR TITLE
Add support for linking and archiving commands

### DIFF
--- a/source/citnames/CMakeLists.txt
+++ b/source/citnames/CMakeLists.txt
@@ -33,6 +33,8 @@ target_sources(citnames_a
             source/semantic/ToolIntelFortran.cc
             source/semantic/ToolWrapper.cc
             source/semantic/ToolExtendingWrapper.cc
+            source/semantic/ToolLinker.cc
+            source/semantic/ToolAr.cc
         INTERFACE
             $<TARGET_OBJECTS:citnames_a>
         )

--- a/source/citnames/source/Configuration.cc
+++ b/source/citnames/source/Configuration.cc
@@ -67,8 +67,18 @@ namespace cs {
     }
 
     void from_json(const nlohmann::json &j, Output &rhs) {
-        j.at("format").get_to(rhs.format);
-        j.at("content").get_to(rhs.content);
+        if (j.contains("format")) {
+            j.at("format").get_to(rhs.format);
+        }
+        if (j.contains("content")) {
+            j.at("content").get_to(rhs.content);
+        }
+        if (j.contains("link_commands_output")) {
+            j.at("link_commands_output").get_to(rhs.link_commands_output);
+        }
+        if (j.contains("ar_commands_output")) {
+            j.at("ar_commands_output").get_to(rhs.ar_commands_output);
+        }
     }
 
     void to_json(nlohmann::json &j, const Output &rhs) {
@@ -76,6 +86,12 @@ namespace cs {
                 {"format",  rhs.format},
                 {"content", rhs.content},
         };
+        if (!rhs.link_commands_output.empty()) {
+            j["link_commands_output"] = rhs.link_commands_output;
+        }
+        if (!rhs.ar_commands_output.empty()) {
+            j["ar_commands_output"] = rhs.ar_commands_output;
+        }
     }
 
     void from_json(const nlohmann::json &j, CompilerWrapper &rhs) {

--- a/source/citnames/source/Configuration.h
+++ b/source/citnames/source/Configuration.h
@@ -64,6 +64,8 @@ namespace cs {
     struct Output {
         Format format;
         Content content;
+        fs::path link_commands_output;  // Path to the link commands output file
+        fs::path ar_commands_output;    // Path to the ar commands output file
     };
 
     // Represents a compiler wrapper that the tool will recognize.

--- a/source/citnames/source/semantic/Build.cc
+++ b/source/citnames/source/semantic/Build.cc
@@ -23,7 +23,9 @@
 #include "ToolClang.h"
 #include "ToolCuda.h"
 #include "ToolIntelFortran.h"
+#include "ToolLinker.h"
 #include "ToolWrapper.h"
+#include "ToolAr.h"
 #include "ToolExtendingWrapper.h"
 #include "Convert.h"
 
@@ -46,6 +48,8 @@ namespace {
                 std::make_shared<cs::semantic::ToolWrapper>(),
                 std::make_shared<cs::semantic::ToolCuda>(),
                 std::make_shared<cs::semantic::ToolIntelFortran>(),
+                std::make_shared<cs::semantic::ToolLinker>(),
+                std::make_shared<cs::semantic::ToolAr>(),
         };
         for (auto && compiler : cfg.compilers_to_recognize) {
             tools.emplace_front(std::make_shared<cs::semantic::ToolExtendingWrapper>(std::move(compiler)));

--- a/source/citnames/source/semantic/Common.cc
+++ b/source/citnames/source/semantic/Common.cc
@@ -17,10 +17,14 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <spdlog/spdlog.h>
+#include <fmt/format.h>
+
 #include "Common.h"
 
 #include <string_view>
 #include <tuple>
+#include <ranges>
 
 using namespace cs::semantic;
 
@@ -79,6 +83,87 @@ namespace {
             return (flag.type == CompilerFlagType::KIND_OF_OUTPUT_NO_LINKING);
         });
     }
+
+    std::tuple<
+        Arguments,
+        std::vector<fs::path>,
+        std::optional<fs::path>>
+    split_linker_flags(const CompilerFlags& flags)
+    {
+        Arguments arguments;
+        std::vector<fs::path> inputs;
+        std::optional<fs::path> output;
+
+        for (const auto& flag : flags) {
+            switch (flag.type) {
+            case CompilerFlagType::LINKER_OBJECT_FILE:
+            case CompilerFlagType::LINKER_STATIC_LIBRARY:
+            case CompilerFlagType::LINKER_SHARED_LIBRARY: {
+                // For linking, we consider object files, and libraries as inputs
+                auto candidate = fs::path(flag.arguments.front());
+                inputs.emplace_back(std::move(candidate));
+                break;
+            }
+            case CompilerFlagType::KIND_OF_OUTPUT_OUTPUT: {
+                auto candidate = fs::path(flag.arguments.back());
+                output = std::make_optional(std::move(candidate));
+                break;
+            }
+            default: {
+                std::copy(flag.arguments.begin(), flag.arguments.end(), std::back_inserter(arguments));
+                break;
+            }
+            }
+        }
+        return std::make_tuple(arguments, inputs, output);
+    }
+
+    std::tuple<
+        Arguments,
+        std::vector<fs::path>,
+        std::optional<fs::path>>
+    split_archiving_flags(const CompilerFlags& flags)
+    {
+        Arguments arguments;
+        std::vector<fs::path> inputs;
+        std::optional<fs::path> output;
+
+        // Find the operation flag first
+        std::string operation;
+        for (const auto& flag : flags) {
+            const auto& arg = flag.arguments.front();
+            if (arg == "r" || arg == "q" || arg == "t" || arg == "x" || 
+                arg == "d" || arg == "m" || arg == "p") {
+                operation = arg;
+                break;
+            }
+        }
+
+        // Then process all flags
+        for (const auto& flag : flags) {
+            switch (flag.type) {
+            case CompilerFlagType::LINKER_STATIC_LIBRARY: {
+                auto candidate = fs::path(flag.arguments.front());
+                output = std::make_optional(std::move(candidate));
+                break;
+            }
+            case CompilerFlagType::LINKER_OBJECT_FILE: {
+                auto candidate = fs::path(flag.arguments.front());
+                inputs.emplace_back(std::move(candidate));
+                break;
+            }
+            default: {
+                std::copy(flag.arguments.begin(), flag.arguments.end(), std::back_inserter(arguments));
+                break;
+            }
+            }
+        }
+
+        // Construct final arguments in correct order: operation, modifiers
+        Arguments final_arguments;
+        std::copy(arguments.begin(), arguments.end(), std::back_inserter(final_arguments));
+        return std::make_tuple(final_arguments, inputs, output);
+    }
 }
 
 rust::Result<SemanticPtr> cs::semantic::compilation_impl(const FlagsByName& flags, const Execution& execution,
@@ -118,6 +203,111 @@ rust::Result<SemanticPtr> cs::semantic::compilation_impl(const FlagsByName& flag
                 execution.executable,
                 std::move(arguments),
                 std::move(sources),
+                std::move(output));
+            return rust::Ok(std::move(result));
+        });
+}
+
+rust::Result<SemanticPtr> cs::semantic::linking_impl(const FlagsByName& flags, const Execution& execution)
+{
+    const auto& parser = Repeat(
+        OneOf(
+            FlagParser(flags),
+            SourceMatcher(),
+            ObjectAndLibraryMatcher(),
+            EverythingElseFlagMatcher()));
+
+    const Arguments input_arguments(execution.arguments.begin(), execution.arguments.end());
+    return parse(parser, input_arguments)
+        .and_then<SemanticPtr>([&execution](auto flags) -> rust::Result<SemanticPtr> {
+            // Add debug logging for parsed flags
+            spdlog::debug("Parsed {} flags for linking", flags.size());
+            for (const auto& flag : flags) {
+                spdlog::debug("Flag type: {}, arguments: {}", 
+                    static_cast<int>(flag.type),
+                    fmt::join(flag.arguments.begin(), flag.arguments.end(), " "));
+            }
+
+            auto [arguments, inputs, output] = split_linker_flags(flags);
+            
+            // Add debug logging for split results
+            spdlog::debug("Split linker flags:");
+            spdlog::debug("Arguments: {}", fmt::join(arguments, " "));
+            
+            // Convert paths to strings for logging
+            std::vector<std::string> input_strings;
+            input_strings.reserve(inputs.size());
+            std::transform(inputs.begin(), inputs.end(), 
+                         std::back_inserter(input_strings),
+                         [](const fs::path& p) { return p.string(); });
+            spdlog::debug("Input files: {}", fmt::join(input_strings, ", "));
+            
+            spdlog::debug("Output file: {}", 
+                output.has_value() ? output.value().string() : "not specified");
+
+            // Validate: must have input files
+            if (inputs.empty()) {
+                spdlog::error("No input files found for linking");
+                return rust::Err(std::runtime_error("Input files not found for linking."));
+            }
+
+            std::list<fs::path> input_files(inputs.begin(), inputs.end());
+
+            SemanticPtr result = std::make_shared<Link>(
+                execution.working_dir,
+                execution.executable,
+                std::move(arguments),
+                std::move(input_files),
+                std::move(output));
+            return rust::Ok(std::move(result));
+        });
+}
+
+rust::Result<SemanticPtr> cs::semantic::archiving_impl(const FlagsByName& flags, const Execution& execution)
+{
+    const auto& parser = Repeat(
+        OneOf(
+            FlagParser(flags),
+            SourceMatcher(),
+            ObjectAndLibraryMatcher(),
+            EverythingElseFlagMatcher()));
+
+    const Arguments input_arguments(execution.arguments.begin(), execution.arguments.end());
+    return parse(parser, input_arguments)
+        .and_then<SemanticPtr>([&execution](auto flags) -> rust::Result<SemanticPtr> {
+            // Find the operation flag
+            std::string operation;
+            for (const auto& flag : flags) {
+                const auto& arg = flag.arguments.front();
+                if (arg == "r" || arg == "q" || arg == "t" || arg == "x" || 
+                    arg == "d" || arg == "m" || arg == "p") {
+                    operation = arg;
+                    break;
+                }
+            }
+
+            if (operation.empty()) {
+                return rust::Err(std::runtime_error("No valid ar operation found."));
+            }
+
+            auto [arguments, inputs, output] = split_archiving_flags(flags);
+
+            // Validate based on operation requirements
+            if (operation == "r" || operation == "q" || operation == "m") {
+                if (inputs.empty()) {
+                    return rust::Err(std::runtime_error("Input files required for this ar operation."));
+                }
+            }
+            if (!output) {
+                return rust::Err(std::runtime_error("Archive file required for ar operation."));
+            }
+
+            SemanticPtr result = std::make_shared<Ar>(
+                execution.working_dir,
+                execution.executable,
+                operation,
+                std::move(arguments),
+                std::list<fs::path>(inputs.begin(), inputs.end()),
                 std::move(output));
             return rust::Ok(std::move(result));
         });

--- a/source/citnames/source/semantic/Common.h
+++ b/source/citnames/source/semantic/Common.h
@@ -28,4 +28,6 @@ namespace cs::semantic {
     rust::Result<SemanticPtr> compilation_impl(const FlagsByName& flags, const Execution& execution,
         std::function<Arguments(const Execution&)> create_argument_list_func,
         std::function<bool(const CompilerFlags&)> is_preprocessor_func);
+    rust::Result<SemanticPtr> linking_impl(const FlagsByName& flags, const Execution& execution);
+    rust::Result<SemanticPtr> archiving_impl(const FlagsByName& flags, const Execution& execution);
 }

--- a/source/citnames/source/semantic/Parsers.h
+++ b/source/citnames/source/semantic/Parsers.h
@@ -108,6 +108,8 @@ namespace cs::semantic {
         PREPROCESSOR_MAKE,
         LINKER,
         LINKER_OBJECT_FILE,
+        LINKER_STATIC_LIBRARY,    // For .a files
+        LINKER_SHARED_LIBRARY,    // For .so files
         DIRECTORY_SEARCH,
         DIRECTORY_SEARCH_LINKER,
         SOURCE,
@@ -174,6 +176,12 @@ namespace cs::semantic {
 
     // Parser combinator which recognize source files as a single argument of a compiler call.
     struct SourceMatcher {
+        [[nodiscard]]
+        static rust::Result<std::pair<CompilerFlag, ArgumentsView>, ArgumentsView> parse(const ArgumentsView &input);
+    };
+
+    // A parser combinator which recognizes object files and libraries.
+    struct ObjectAndLibraryMatcher {
         [[nodiscard]]
         static rust::Result<std::pair<CompilerFlag, ArgumentsView>, ArgumentsView> parse(const ArgumentsView &input);
     };

--- a/source/citnames/source/semantic/Semantic.h
+++ b/source/citnames/source/semantic/Semantic.h
@@ -101,4 +101,61 @@ namespace cs::semantic {
         std::vector<fs::path> sources;
         std::optional<fs::path> output;
     };
+
+    class Link : public CompilerCall {
+    public:
+        Link(fs::path working_dir,
+             fs::path linker,
+             std::list<std::string> flags,
+             std::list<fs::path> input_files,
+             std::optional<fs::path> output = std::nullopt)
+            : working_dir(std::move(working_dir))
+            , linker(std::move(linker))
+            , flags(std::move(flags))
+            , input_files(std::move(input_files))
+            , output(std::move(output))
+        { }
+
+        bool operator==(Semantic const& rhs) const override;
+        std::list<cs::Entry> into_entries() const override;
+        std::list<cs::LinkEntry> into_link_entries() const;
+        std::ostream& operator<<(std::ostream& os) const override;
+
+    private:
+        fs::path working_dir;
+        fs::path linker;
+        std::list<std::string> flags;
+        std::list<fs::path> input_files;
+        std::optional<fs::path> output;
+    };
+
+    class Ar : public CompilerCall {
+    public:
+        Ar(fs::path working_dir,
+           fs::path ar_tool,
+           std::string operation,
+           std::list<std::string> flags,
+           std::list<fs::path> input_files,
+           std::optional<fs::path> output = std::nullopt)
+            : working_dir(std::move(working_dir))
+            , ar_tool(std::move(ar_tool))
+            , operation(std::move(operation))
+            , flags(std::move(flags))
+            , input_files(std::move(input_files))
+            , output(std::move(output))
+        { }
+
+        bool operator==(Semantic const& rhs) const override;
+        std::list<cs::Entry> into_entries() const override;
+        std::list<cs::ArEntry> into_ar_entries() const;
+        std::ostream& operator<<(std::ostream& os) const override;
+
+    private:
+        fs::path working_dir;
+        fs::path ar_tool;
+        std::string operation;  // Keep this for internal use
+        std::list<std::string> flags;  // This will include the operation
+        std::list<fs::path> input_files;
+        std::optional<fs::path> output;
+    };
 }

--- a/source/citnames/source/semantic/ToolAr.cc
+++ b/source/citnames/source/semantic/ToolAr.cc
@@ -1,0 +1,77 @@
+#include "ToolAr.h"
+#include "Semantic.h"
+#include "Common.h"
+#include "libshell/Command.h"
+#include "Parsers.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <regex>
+#include <map>
+#include <iostream>
+
+namespace {
+    const std::regex AR_PATTERN(R"(^(ar|llvm-ar)$)");
+}
+
+namespace cs::semantic {
+
+    const FlagsByName ToolAr::FLAG_DEFINITION = {
+            // Main operation flags - all operations should be part of arguments
+            {"r", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Replace or insert files
+            {"q", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Quick append
+            {"t", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // List contents
+            {"x", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Extract
+            {"d", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Delete
+            {"m", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Move
+            {"p", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Print
+            
+            // Operation modifiers
+            {"a", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Put files after [member-name]
+            {"b", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Put files before [member-name]
+            {"i", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Same as [b]
+            {"D", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Use zero for timestamps and uids/gids
+            {"U", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Use actual timestamps and uids/gids
+            {"N", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Use instance [count] of name
+            {"f", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Truncate inserted file names
+            {"P", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Use full path names when matching
+            {"o", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Preserve original dates
+            {"O", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Display offsets of files
+            {"u", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Only replace newer files
+            
+            // Generic modifiers
+            {"c", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Don't warn if library had to be created
+            {"s", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Create an archive index
+            {"S", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Don't build a symbol table
+            {"T", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Deprecated, use --thin instead
+            {"v", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Be verbose
+            {"V", {MatchInstruction::EXACTLY, CompilerFlagType::KIND_OF_OUTPUT_INFO}},  // Display version number
+            
+            // Long options
+            {"--thin", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},  // Make a thin archive
+            {"--plugin", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},  // Load specified plugin
+            {"--target", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},  // Specify target object format
+            {"--output", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::KIND_OF_OUTPUT_OUTPUT}},  // Specify output directory
+            {"--record-libdeps", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},  // Specify library dependencies
+    };
+
+    bool ToolAr::is_ar_call(const fs::path& program) const {
+        const auto name = program.filename().string();
+        return std::regex_match(name, AR_PATTERN);
+    }
+
+    rust::Result<SemanticPtr> ToolAr::recognize(const Execution &execution) const {
+        if (is_ar_call(execution.executable)) {
+            return archiving(execution);
+        }
+        return rust::Ok(SemanticPtr());
+    }
+
+    rust::Result<SemanticPtr> ToolAr::archiving(const Execution &execution) const {
+        return archiving(FLAG_DEFINITION, execution);
+    }
+
+    rust::Result<SemanticPtr> ToolAr::archiving(const FlagsByName &flags, const Execution &execution) {
+        return archiving_impl(flags, execution);
+    }
+} 

--- a/source/citnames/source/semantic/ToolAr.h
+++ b/source/citnames/source/semantic/ToolAr.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Tool.h"
+#include "Parsers.h"
+
+namespace cs::semantic {
+
+    struct ToolAr : public Tool {
+
+        [[nodiscard]]
+        rust::Result<SemanticPtr> recognize(const Execution &execution) const override;
+
+    protected:
+        [[nodiscard]]
+        bool is_ar_call(const fs::path& program) const;
+
+        [[nodiscard]]
+        rust::Result<SemanticPtr> archiving(const Execution &execution) const;
+
+        [[nodiscard]]
+        static rust::Result<SemanticPtr> archiving(const FlagsByName &flags, const Execution &execution);
+
+        static const FlagsByName FLAG_DEFINITION;
+    };
+} 

--- a/source/citnames/source/semantic/ToolLinker.cc
+++ b/source/citnames/source/semantic/ToolLinker.cc
@@ -1,0 +1,75 @@
+#include "ToolLinker.h"
+#include "Semantic.h"
+#include "Common.h"
+#include "libshell/Command.h"
+#include "Parsers.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <regex>
+#include <map>
+#include <iostream>
+
+namespace {
+    const std::regex LINKER_PATTERN(R"(^(ld|ld\.gold|ld\.lld|gold|lld)$)");
+}
+
+namespace cs::semantic {
+
+    const FlagsByName ToolLinker::FLAG_DEFINITION = {
+            // Output flags
+            {"-o", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::KIND_OF_OUTPUT_OUTPUT}},
+            {"--output", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::KIND_OF_OUTPUT_OUTPUT}},
+            
+            // Library flags
+            {"-l", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"-L", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::DIRECTORY_SEARCH_LINKER}},
+            {"--library", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--library-path", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::DIRECTORY_SEARCH_LINKER}},
+            
+            // Runtime path flags
+            {"-rpath", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--rpath", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            
+            // Shared library flags
+            {"-soname", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--soname", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            
+            // Version script flags
+            {"-version-script", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--version-script", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            
+            // Dynamic linker flags
+            {"-dynamic-linker", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--dynamic-linker", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            
+            // Other common linker flags
+            {"-z", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"-m", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--hash-style", {MatchInstruction::EXACTLY_WITH_1_OPT_SEP, CompilerFlagType::LINKER}},
+            {"--build-id", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},
+            {"--eh-frame-hdr", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},
+            {"--as-needed", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},
+            {"--no-as-needed", {MatchInstruction::EXACTLY, CompilerFlagType::LINKER}},
+    };
+
+    bool ToolLinker::is_linker_call(const fs::path& program) const {
+        const auto name = program.filename().string();
+        return std::regex_match(name, LINKER_PATTERN);
+    }
+
+    rust::Result<SemanticPtr> ToolLinker::recognize(const Execution &execution) const {
+        if (is_linker_call(execution.executable)) {
+            return linking(execution);
+        }
+        return rust::Ok(SemanticPtr());
+    }
+
+    rust::Result<SemanticPtr> ToolLinker::linking(const Execution &execution) const {
+        return linking(FLAG_DEFINITION, execution);
+    }
+
+    rust::Result<SemanticPtr> ToolLinker::linking(const FlagsByName &flags, const Execution &execution) {
+        return linking_impl(flags, execution);
+    }
+} 

--- a/source/citnames/source/semantic/ToolLinker.h
+++ b/source/citnames/source/semantic/ToolLinker.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Tool.h"
+#include "Parsers.h"
+
+namespace cs::semantic {
+
+    struct ToolLinker : public Tool {
+
+        [[nodiscard]]
+        rust::Result<SemanticPtr> recognize(const Execution &execution) const override;
+
+    protected:
+        [[nodiscard]]
+        bool is_linker_call(const fs::path& program) const;
+
+        [[nodiscard]]
+        rust::Result<SemanticPtr> linking(const Execution &execution) const;
+
+        [[nodiscard]]
+        static rust::Result<SemanticPtr> linking(const FlagsByName &flags, const Execution &execution);
+
+        static const FlagsByName FLAG_DEFINITION;
+    };
+} 

--- a/source/citnames/test/ParserTest.cc
+++ b/source/citnames/test/ParserTest.cc
@@ -49,6 +49,27 @@ namespace cs::semantic {
 
 namespace {
 
+    TEST(Parser, ObjectAndLibraryMatcher) {
+        const auto sut = Repeat(ObjectAndLibraryMatcher());
+
+        {
+            const Arguments input = {"compiler", "file.o", "lib.a", "lib.so"};
+            const auto flags = parse(sut, input);
+            EXPECT_TRUE(flags.is_ok());
+            const CompilerFlags expected = {
+                    CompilerFlag{slice(input, 1), CompilerFlagType::LINKER_OBJECT_FILE},
+                    CompilerFlag{slice(input, 2), CompilerFlagType::LINKER_STATIC_LIBRARY},
+                    CompilerFlag{slice(input, 3), CompilerFlagType::LINKER_SHARED_LIBRARY},
+            };
+            EXPECT_EQ(expected, flags.unwrap());
+        }
+        {
+            const Arguments input = {"compiler", "file.txt"};
+            const auto flags = parse(sut, input);
+            EXPECT_TRUE(flags.is_err());
+        }
+    }
+
     TEST(Parser, EverythingElseFlagMatcher) {
         const auto sut = Repeat(EverythingElseFlagMatcher());
 
@@ -56,10 +77,10 @@ namespace {
         const auto flags = parse(sut, input);
         EXPECT_TRUE(flags.is_ok());
         const CompilerFlags expected = {
-                CompilerFlag{slice(input, 1), CompilerFlagType::LINKER_OBJECT_FILE},
-                CompilerFlag{slice(input, 2), CompilerFlagType::LINKER_OBJECT_FILE},
-                CompilerFlag{slice(input, 3), CompilerFlagType::LINKER_OBJECT_FILE},
-                CompilerFlag{slice(input, 4), CompilerFlagType::LINKER_OBJECT_FILE},
+                CompilerFlag{slice(input, 1), CompilerFlagType::OTHER},
+                CompilerFlag{slice(input, 2), CompilerFlagType::OTHER},
+                CompilerFlag{slice(input, 3), CompilerFlagType::OTHER},
+                CompilerFlag{slice(input, 4), CompilerFlagType::OTHER},
         };
         EXPECT_EQ(expected, flags.unwrap());
     }


### PR DESCRIPTION
# Add Support for Link and Archive Commands

## Problem
Currently, Bear lacks comprehensive support for properly handling linker and archive (ar) commands in the compilation database. While previous pr #529 try to implement this functionality, there are no progress in that track for too long.

## Proposed Solution
Implement dedicated handlers for both link and archive commands to enhance Bear's compilation database generation capabilities:

1. **Linker Command Support (`ToolLinker`)**:
   - Recognize common linker invocations (ld, gold, lld)
   - Parse relevant linker flags and input files

2. **Archive Command Support (`ToolAr`)**:
   - Support standard ar command operations
   - Parse archive member specifications
   - Handle common ar flags and operations

Options are added to the config, example config to generate link_commands.json and ar_commands.json:
```json
{
    "output": {
        "format": {
            "command_as_array": true,
            "drop_output_field": false
        },
        "content": {
            "include_only_existing_source": true,
            "duplicate_filter_fields": "file_output"
        },
        "link_commands_output": "link_commands.json",
        "ar_commands_output": "ar_commands.json"
    }
} 
```

## Future Considerations
- Unit tests

Suggestions for improvement and organization of the code are welcome.