### PR TITLE
citnames: add xgcc and xg++

### DIFF
--- a/source/citnames/source/semantic/ToolGcc.cc
+++ b/source/citnames/source/semantic/ToolGcc.cc
@@ -205,7 +205,9 @@ namespace cs::semantic {
                 //   - with prefixes like: arm-none-eabi-
                 //   - with postfixes like: -7.0 or 6.4.0
                 // - (excluding cc1)
-            R"(^(cxx|CC|(([^-]*-)*(cc(?!1(?![\d\.]))|[mg]cc|[cmg]\+\+|[g]?fortran)(-?\d+(\.\d+){0,2})?))$)"
+                // - xgcc
+                // - xg++
+            R"(^(cxx|CC|(([^-]*-)*(cc(?!1(?![\d\.]))|[mg]cc|[cmg]\+\+|[g]?fortran)(-?\d+(\.\d+){0,2})?)|xgcc|xg\+\+)$)"
         );
 
         std::cmatch m;


### PR DESCRIPTION
When building gcc and g++, the compiler core is first built as xgcc/xg++, and these are then used to compile other components (e.g. libgcc or libstdc++). Since xgcc/xg++ were not recognized by bear, many files were missing from compile_commands.json when building gcc.

    # building gcc (master branch) on x86_64 Linux
    ../configure --disable-bootstrap --disable-multilib --enable-languages=c,c++
    bear -- make
    jq 'length' compile_commands.json
    # before this change: 1067
    # after  this change: 2745

Fixes: https://github.com/rizsotto/Bear/issues/563