### PR TITLE
Add support for sccache

### DIFF
--- a/source/citnames/source/semantic/ToolWrapper.cc
+++ b/source/citnames/source/semantic/ToolWrapper.cc
@@ -56,7 +56,7 @@ namespace cs::semantic {
 
     bool ToolWrapper::is_ccache_call(const fs::path &program) {
         const auto string = program.filename().string();
-        return string == "ccache";
+        return string == "ccache" || string == "sccache";
     }
 
     bool ToolWrapper::is_ccache_query(const std::list<std::string> &arguments) {

--- a/source/citnames/test/ToolWrapperTest.cc
+++ b/source/citnames/test/ToolWrapperTest.cc
@@ -95,13 +95,13 @@ namespace {
     }
 
     TEST(ToolWrapper, is_distcc_query) {
-        EXPECT_TRUE(ToolWrapper::is_ccache_query({"distcc"}));
-        EXPECT_TRUE(ToolWrapper::is_ccache_query({"distcc", "--help"}));
-        EXPECT_TRUE(ToolWrapper::is_ccache_query({"distcc", "--show-hosts"}));
-        EXPECT_TRUE(ToolWrapper::is_ccache_query({"distcc", "-j"}));
+        EXPECT_TRUE(ToolWrapper::is_distcc_query({"distcc"}));
+        EXPECT_TRUE(ToolWrapper::is_distcc_query({"distcc", "--help"}));
+        EXPECT_TRUE(ToolWrapper::is_distcc_query({"distcc", "--show-hosts"}));
+        EXPECT_TRUE(ToolWrapper::is_distcc_query({"distcc", "-j"}));
 
-        EXPECT_FALSE(ToolWrapper::is_ccache_query({"distcc", "cc", "--help"}));
-        EXPECT_FALSE(ToolWrapper::is_ccache_query({"distcc", "cc", "-c"}));
+        EXPECT_FALSE(ToolWrapper::is_distcc_query({"distcc", "cc", "--help"}));
+        EXPECT_FALSE(ToolWrapper::is_distcc_query({"distcc", "cc", "-c"}));
     }
 
     TEST(ToolWrapper, remove_wrapper) {

--- a/source/citnames/test/ToolWrapperTest.cc
+++ b/source/citnames/test/ToolWrapperTest.cc
@@ -66,14 +66,19 @@ namespace {
         EXPECT_FALSE(ToolWrapper::is_ccache_call("/usr/bin/g++"));
 
         EXPECT_TRUE(ToolWrapper::is_ccache_call("ccache"));
+        EXPECT_TRUE(ToolWrapper::is_ccache_call("sccache"));
     }
 
     TEST(ToolWrapper, is_ccache_query) {
         EXPECT_TRUE(ToolWrapper::is_ccache_query({"ccache"}));
         EXPECT_TRUE(ToolWrapper::is_ccache_query({"ccache", "-c"}));
         EXPECT_TRUE(ToolWrapper::is_ccache_query({"ccache", "--cleanup"}));
+        EXPECT_TRUE(ToolWrapper::is_ccache_query({"sccache"}));
+        EXPECT_TRUE(ToolWrapper::is_ccache_query({"sccache", "-s"}));
+        EXPECT_TRUE(ToolWrapper::is_ccache_query({"sccache", "-h"}));
 
         EXPECT_FALSE(ToolWrapper::is_ccache_query({"ccache", "cc", "-c"}));
+        EXPECT_FALSE(ToolWrapper::is_ccache_query({"sccache", "cc", "-c"}));
     }
 
     TEST(ToolWrapper, is_distcc_call) {


### PR DESCRIPTION
This adds support for the [sccache](https://github.com/mozilla/sccache) compiler wrapper by treating it as a variant of `ccache`.

I added some basic tests derived from the `ccache` tests, and also updated the `is_distcc_query` tests while I was at it because they were calling `is_ccache_query` instead of `is_distcc_query` (which I assume was what was actually meant to be tested).