### PR TITLE
Remove USE_SOURCE_PERMISSIONS from install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,6 @@ install(DIRECTORY
             ${STAGED_INSTALL_PREFIX}/
         DESTINATION
             .
-        USE_SOURCE_PERMISSIONS
 )
 install(FILES
             COPYING README.md INSTALL.md CONTRIBUTING.md CODE_OF_CONDUCT.md


### PR DESCRIPTION
The `USE_SOURCE_PERMISSIONS` option in the `install(DIRECTORY)` command was causing issues with file permissions after `cmake install`. Specifically, it was altering the permissions of the `bin`, `lib`, and `share` folders, leading to `others` losing access to these directories. Removing this option ensures that default permissions are maintained, preventing unexpected access restrictions for users.