### PR TITLE
fix: add -arch flag to GCC flags to prevent argument loss on macOS ARM

### DIFF
--- a/bear/src/semantic/interpreters/compilers/gcc.rs
+++ b/bear/src/semantic/interpreters/compilers/gcc.rs
@@ -1496,23 +1496,17 @@ mod tests {
 
         // On macOS, cc/gcc are Apple Clang and pass -arch arm64.
         // The -arch flag takes one argument; both must be preserved.
-        let execution = create_execution(
-            "cc",
-            vec!["cc", "-arch", "arm64", "-Wall", "-O2", "-c", "hello.c"],
-            "/project",
-        );
+        let execution =
+            create_execution("cc", vec!["cc", "-arch", "arm64", "-Wall", "-O2", "-c", "hello.c"], "/project");
 
         let result = interpreter.recognize(&execution).unwrap();
 
         if let Command::Compiler(cmd) = result {
             // -arch arm64 must be recognised as a single two-token flag
-            let arch_arg = cmd
-                .arguments
-                .iter()
-                .find(|a| {
-                    let tokens = a.as_arguments(&|p| Cow::Borrowed(p));
-                    tokens.len() == 2 && tokens[0] == "-arch" && tokens[1] == "arm64"
-                });
+            let arch_arg = cmd.arguments.iter().find(|a| {
+                let tokens = a.as_arguments(&|p| Cow::Borrowed(p));
+                tokens.len() == 2 && tokens[0] == "-arch" && tokens[1] == "arm64"
+            });
             assert!(arch_arg.is_some(), "-arch arm64 should be captured as a single argument pair");
             assert_eq!(
                 arch_arg.unwrap().kind(),
@@ -1520,13 +1514,10 @@ mod tests {
             );
 
             // arm64 must NOT appear as a source file
-            let bad_source = cmd
-                .arguments
-                .iter()
-                .any(|a| {
-                    let tokens = a.as_arguments(&|p| Cow::Borrowed(p));
-                    tokens.len() == 1 && tokens[0] == "arm64"
-                });
+            let bad_source = cmd.arguments.iter().any(|a| {
+                let tokens = a.as_arguments(&|p| Cow::Borrowed(p));
+                tokens.len() == 1 && tokens[0] == "arm64"
+            });
             assert!(!bad_source, "arm64 must not be misclassified as a source file");
         } else {
             panic!("Expected compiler command");


### PR DESCRIPTION
## Summary

Fixes #673

## Fix

Add `-arch` and `-arch_only` to `GCC_FLAGS` so the parser correctly consumes the flag + value pair. This is safe because:
- On macOS, `gcc`/`cc` are Apple Clang and do use `-arch`
- On Linux, real GCC doesn't use `-arch`, so the rule simply never matches
- The same flags already exist in `CLANG_FLAGS` with identical definitions

## Reproduction

```makefile
CC = cc
CFLAGS = -arch arm64 -Wall -Wextra -O2

hello: hello.c
	$(CC) $(CFLAGS) -o hello hello.c
```

```bash
make clean && bear -- make
# Before fix: compile_commands.json has "-arch", "-Wall" (arm64 missing)
# After fix:  compile_commands.json has "-arch", "arm64", "-Wall" (correct)
```

## Test plan

- [x] Added `test_arch_flag_preserves_argument` unit test
