### PR TITLE
Follow up MSVC support with Windows wrapper resolution fixes

### DIFF
--- a/bear/src/intercept/environment.rs
+++ b/bear/src/intercept/environment.rs
@@ -235,6 +235,9 @@ impl BuildEnvironment {
 
     fn resolve_program_path(context: &context::Context, value: &str) -> Option<PathBuf> {
         let executable = Self::extract_program_from_env(value)?;
+        if executable.as_os_str().is_empty() {
+            return None;
+        }
 
         if executable.is_absolute() {
             return Some(executable.canonicalize().unwrap_or(executable));

--- a/bear/src/intercept/environment.rs
+++ b/bear/src/intercept/environment.rs
@@ -171,10 +171,12 @@ impl BuildEnvironment {
         let mut environment_overrides = HashMap::new();
         for (key, value) in &context.environment {
             if crate::environment::program_env(key) && !value.is_empty() {
-                let program_path = std::path::PathBuf::from(value);
-                let wrapper_path = wrapper_dir_builder.register_executable(program_path)?;
-                // Update the environment overrides with the wrapper path
-                environment_overrides.insert(key.clone(), wrapper_path.to_string_lossy().to_string());
+                if let Some(program_path) = Self::resolve_program_path(context, value) {
+                    let wrapper_path = wrapper_dir_builder.register_executable(program_path)?;
+                    environment_overrides.insert(key.clone(), wrapper_path.to_string_lossy().to_string());
+                } else {
+                    log::debug!("Skipping unresolved compiler environment override: {key}={value}");
+                }
             }
         }
 
@@ -229,6 +231,41 @@ impl BuildEnvironment {
                 }
             })
             .filter(move |path| is_executable_file(path) && predicate(path))
+    }
+
+    fn resolve_program_path(context: &context::Context, value: &str) -> Option<PathBuf> {
+        let executable = Self::extract_program_from_env(value)?;
+
+        if executable.is_absolute() {
+            return Some(executable.canonicalize().unwrap_or(executable));
+        }
+
+        if executable.parent().is_some_and(|parent| !parent.as_os_str().is_empty()) {
+            let absolute = context.current_directory.join(executable);
+            return Some(absolute.canonicalize().unwrap_or(absolute));
+        }
+
+        let search_path = context.path().map(|(_, path)| path).unwrap_or_else(|| context.confstr_path.clone());
+        which::which_in(&executable, Some(search_path.as_str()), &context.current_directory).ok()
+    }
+
+    fn extract_program_from_env(value: &str) -> Option<PathBuf> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix('"') {
+            let end = rest.find('"')?;
+            return Some(PathBuf::from(&rest[..end]));
+        }
+
+        if let Some(rest) = trimmed.strip_prefix('\'') {
+            let end = rest.find('\'')?;
+            return Some(PathBuf::from(&rest[..end]));
+        }
+
+        trimmed.split_whitespace().next().map(PathBuf::from)
     }
 
     /// Creates a `BuildEnvironment` configured for preload mode interception.
@@ -884,5 +921,52 @@ mod test {
         // Should NOT have gcc from PATH (PATH discovery should be skipped)
         // The gcc in bin_dir should not be discovered because we provided explicit executables
         assert!(wrapper_config.get_executable("gcc").is_none(), "gcc from PATH should not be discovered");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_program_env_resolution_uses_path_on_windows() {
+        let current_dir = TempDir::new().unwrap();
+        let install_dir = {
+            let dir = TempDir::new().unwrap();
+            let bin_dir = dir.path().join("bin");
+            std::fs::create_dir(&bin_dir).unwrap();
+            let file = bin_dir.join(env!("WRAPPER_NAME"));
+            std::fs::write(&file, "wrapper").unwrap();
+            dir
+        };
+
+        let tool_dir = TempDir::new().unwrap();
+        let compiler_path = tool_dir.path().join("cl.exe");
+        std::fs::write(&compiler_path, "compiler").unwrap();
+
+        let context = {
+            let mut environment = HashMap::new();
+            environment.insert("PATH".to_string(), tool_dir.path().to_string_lossy().to_string());
+            environment.insert("CC".to_string(), "cl".to_string());
+
+            crate::context::Context {
+                current_executable: install_dir.path().join("bin").join("bear-driver.exe"),
+                current_directory: current_dir.path().to_path_buf(),
+                environment,
+                preload_supported: false,
+                confstr_path: String::new(),
+            }
+        };
+
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+        let sut = BuildEnvironment::create_as_wrapper(&context, &[], address, |_| false).unwrap();
+
+        let wrapper_dir = sut._wrapper_directory.as_ref().expect("Wrapper directory should exist");
+        let wrapper_config = wrapper_dir.config();
+
+        assert_eq!(wrapper_config.get_executable("cl.EXE"), Some(&compiler_path));
+
+        let cc_value = sut.environment_overrides.get("CC").expect("CC should be overridden");
+        assert!(
+            cc_value.ends_with("cl.exe"),
+            "CC should point to a wrapper executable with .exe extension: {}",
+            cc_value
+        );
     }
 }

--- a/bear/src/intercept/wrapper.rs
+++ b/bear/src/intercept/wrapper.rs
@@ -92,8 +92,32 @@ impl WrapperConfig {
 
     /// Gets the real executable path for a given wrapper name.
     pub fn get_executable(&self, name: &str) -> Option<&PathBuf> {
-        self.executables.get(name)
+        if let Some(path) = self.executables.get(name) {
+            return Some(path);
+        }
+
+        #[cfg(windows)]
+        {
+            let normalized_name = normalize_windows_executable_name(name);
+            return self
+                .executables
+                .iter()
+                .find_map(|(candidate, path)| {
+                    (normalize_windows_executable_name(candidate) == normalized_name).then_some(path)
+                });
+        }
+
+        #[cfg(not(windows))]
+        {
+            None
+        }
     }
+}
+
+#[cfg(windows)]
+fn normalize_windows_executable_name(name: &str) -> String {
+    let lowercase = name.to_ascii_lowercase();
+    lowercase.strip_suffix(".exe").unwrap_or(&lowercase).to_string()
 }
 
 impl Display for WrapperConfig {
@@ -344,6 +368,20 @@ mod tests {
         assert_eq!(config.get_executable("gcc"), Some(&PathBuf::from("/usr/bin/gcc")));
         assert_eq!(config.get_executable("g++"), Some(&PathBuf::from("/usr/bin/g++")));
         assert_eq!(config.get_executable("clang"), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_wrapper_config_get_executable_windows_case_insensitive_and_extension_agnostic() {
+        let config = {
+            let mut builder = WrapperConfig::new(address());
+            builder.add_executable("cl".to_string(), PathBuf::from(r"C:\VS\cl.exe"));
+            builder
+        };
+
+        assert_eq!(config.get_executable("cl"), Some(&PathBuf::from(r"C:\VS\cl.exe")));
+        assert_eq!(config.get_executable("cl.exe"), Some(&PathBuf::from(r"C:\VS\cl.exe")));
+        assert_eq!(config.get_executable("cl.EXE"), Some(&PathBuf::from(r"C:\VS\cl.exe")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is a Windows wrapper-mode follow-up to commit `4e983b53951e88e7fa1cef9fa5afce021ccbb4ab`, which added MSVC and clang-cl support.

This patch:
- resolves compiler-like environment variable values such as `CC=cl` through `PATH` before wrapper targets are registered
- normalizes Windows wrapper config lookup so casing and optional `.exe` suffix do not break executable resolution
- adds focused Windows tests for both behaviors

Fixes #686.

## Tests

- `cargo test --manifest-path bear/Cargo.toml -p bear --lib intercept::environment::test::test_program_env_resolution_uses_path_on_windows -- --exact`
- `cargo test --manifest-path bear/Cargo.toml -p bear --lib intercept::wrapper::tests::test_wrapper_config_get_executable_windows_case_insensitive_and_extension_agnostic -- --exact`