### PR TITLE
Update INSTALL.md with 'lld' requirement for Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,7 @@ Ensure that `cargo` and `rustc` are available in your `PATH`:
 **C compiler**: A C compiler is required to build the preload library
 (`intercept-preload`). The `cc` crate will typically find one automatically;
 ensure `gcc` or `clang` is installed.
+If your are building for Linux/ELF platform, ensure `lld` is installed, as `ld` lacks an essetial feature.
 
 ## Simple installation
 


### PR DESCRIPTION
Added note about the requirement of 'lld' for Linux/ELF platform. Follow-up of the commit ead6251 (Clarify comment about forcing lld linker), which affected a comment in `intercept-preload/build.rs` file for version 4.1.0.