### PR TITLE
fix: intercept pclose

### DIFF
--- a/intercept-preload/build.rs
+++ b/intercept-preload/build.rs
@@ -16,6 +16,7 @@ const INTERCEPT_FAMILY: &[&str] = &[
     "execl",
     "execlp",
     "execle",
+    "pclose",
     "posix_spawn",
     "posix_spawnp",
     "popen",

--- a/platform-checks/build.rs
+++ b/platform-checks/build.rs
@@ -44,6 +44,7 @@ const SYMBOL_PROBES: &[(&str, &str)] = &[
     ("execlp", "unistd.h"),
     ("execle", "unistd.h"),
     ("posix_spawn", "spawn.h"),
+    ("pclose", "stdio.h"),
     ("posix_spawnp", "spawn.h"),
     ("popen", "stdio.h"),
     ("system", "stdlib.h"),


### PR DESCRIPTION
Add Pclose to the exposed symbols list so our pclose implementation is called.

This fixes hardened_popen_after_unsetenv test on FreeBSD.