### PR TITLE
fix: Use sh instead of bash

### DIFF
--- a/integration-tests/tests/fixtures/infrastructure/install_environment.rs
+++ b/integration-tests/tests/fixtures/infrastructure/install_environment.rs
@@ -37,7 +37,7 @@ impl InstallEnvironment {
             .parent()
             .with_context(|| "cannot determine artifact directory from DRIVER_EXECUTABLE_PATH")?;
 
-        let output = std::process::Command::new("bash")
+        let output = std::process::Command::new("sh")
             .arg(INSTALL_SCRIPT_PATH)
             .env("PREFIX", destdir)
             .env("INTERCEPT_LIBDIR", INTERCEPT_LIBDIR)


### PR DESCRIPTION
Not all OSes and Linux distributions ship with bash by default. Without installing bash, users may see a confusing “No such file or directory” error.
To avoid this, switch to sh instead, since most systems provide their own POSIX-compatible shell implementation. This minimizes dependencies and improves portability across different operating systems and test environments.